### PR TITLE
removed positions and lanes from initial_config

### DIFF
--- a/flow/core/generator.py
+++ b/flow/core/generator.py
@@ -33,9 +33,9 @@ class Generator(Serializable):
 
         Attributes
         ----------
-        net_params: NetParams type
+        net_params : NetParams type
             see flow/core/params.py
-        base: str
+        base : str
             base name for the transportation network. If not specified in the
             child class, this is also the complete name for the network.
         """
@@ -217,7 +217,7 @@ class Generator(Serializable):
 
         Parameters
         ----------
-        net_params: NetParams type
+        net_params : NetParams type
             see flow/core/params.py
         traffic_lights : flow.core.traffic_lights.TrafficLights type
             traffic light information, used to determine which nodes are
@@ -337,7 +337,7 @@ class Generator(Serializable):
         printxml(cfg, self.cfg_path + self.sumfn)
         return self.sumfn
 
-    def make_routes(self, scenario, initial_config):
+    def make_routes(self, scenario, positions, lanes, shuffle):
         """Generates .rou.xml files using net files and netconvert.
 
         This file specifies the sumo-specific properties of vehicles with
@@ -347,11 +347,16 @@ class Generator(Serializable):
 
         Parameters
         ----------
-        scenario: Scenario type
+        scenario : Scenario type
             scenario class calling this method. This contains information on
             the properties and initial states of vehicles in the network.
-        initial_config: InitialConfig type
-            see flow/core/params.py
+        positions : list of tuple (float, float)
+            list of start positions [(edge0, pos0), (edge1, pos1), ...]
+        lanes : list of float
+            list of start lanes
+        shuffle : bool
+            specifies whether the vehicle IDs should be shuffled before the
+            vehicles are assigned starting positions
         """
         vehicles = scenario.vehicles
         routes = makexml("routes", "http://sumo.dlr.de/xsd/routes_file.xsd")
@@ -366,12 +371,10 @@ class Generator(Serializable):
 
         self.vehicle_ids = vehicles.get_ids()
 
-        if initial_config.shuffle:
+        if shuffle:
             random.shuffle(self.vehicle_ids)
 
         # add the initial positions of vehicles to the xml file
-        positions = initial_config.positions
-        lanes = initial_config.lanes
         for i, veh_id in enumerate(self.vehicle_ids):
             veh_type = vehicles.get_state(veh_id, "type")
             edge, pos = positions[i]
@@ -404,12 +407,12 @@ class Generator(Serializable):
 
         Parameters
         ----------
-        net_params: NetParams type
+        net_params : NetParams type
             see flow/core/params.py
 
         Returns
         -------
-        nodes: list of dict
+        nodes : list of dict
 
             A list of node attributes (a separate dict for each node). Nodes
             attributes must include:
@@ -429,12 +432,12 @@ class Generator(Serializable):
 
         Parameters
         ----------
-        net_params: NetParams type
+        net_params : NetParams type
             see flow/core/params.py
 
         Returns
         -------
-        edges: list of dict
+        edges : list of dict
 
             A list of edges attributes (a separate dict for each edge). Edge
             attributes must include:
@@ -490,7 +493,7 @@ class Generator(Serializable):
 
         Returns
         -------
-        connections: list of dict
+        connections : list of dict
             A list of connection attributes. If none are specified, no .con.xml
             file is created.
 
@@ -510,12 +513,12 @@ class Generator(Serializable):
 
         Parameters
         ----------
-        net_params: NetParams type
+        net_params : NetParams type
             see flow/core/params.py
 
         Returns
         -------
-        routes: dict
+        routes : dict
             Key = name of the starting edge
             Element = list of edges a vehicle starting from this edge must
             traverse.

--- a/flow/core/params.py
+++ b/flow/core/params.py
@@ -196,8 +196,6 @@ class InitialConfig:
                  bunching=0,
                  lanes_distribution=float("inf"),
                  edges_distribution="all",
-                 positions=None,
-                 lanes=None,
                  additional_params=None):
         """Initial configuration parameters.
 
@@ -232,12 +230,6 @@ class InitialConfig:
         edges_distribution: list <str>, optional
             list of edges vehicles may be placed on initialization, default is
             all lanes (stated as "all")
-        positions: list, optional
-            used if the user would like to specify user-generated initial
-            positions.
-        lanes: list, optional
-            used if the user would like to specify user-generated initial
-            positions.
         additional_params: dict, optional
             some other network-specific params
         """
@@ -249,8 +241,6 @@ class InitialConfig:
         self.bunching = bunching
         self.lanes_distribution = lanes_distribution
         self.edges_distribution = edges_distribution
-        self.positions = positions
-        self.lanes = lanes
         self.additional_params = additional_params or dict()
 
     def get_additional_params(self, key):

--- a/flow/scenarios/base_scenario.py
+++ b/flow/scenarios/base_scenario.py
@@ -40,18 +40,18 @@ class Scenario(Serializable):
 
         Attributes
         ----------
-        name: str
+        name : str
             A tag associated with the scenario
-        generator_class: Generator type
+        generator_class : Generator type
             Class for generating configuration and net files with placed
             vehicles, e.g. CircleGenerator
-        vehicles: Vehicles type
+        vehicles : Vehicles type
             see flow/core/vehicles.py
-        net_params: NetParams type
+        net_params : NetParams type
             see flow/core/params.py
-        initial_config: InitialConfig type
+        initial_config : InitialConfig type
             see flow/core/params.py
-        traffic_lights: flow.core.traffic_lights.TrafficLights type
+        traffic_lights : flow.core.traffic_lights.TrafficLights type
             see flow/core/traffic_lights.py
         """
         # Invoke serializable if using rllab
@@ -123,15 +123,14 @@ class Scenario(Serializable):
             ])
 
         # generate starting position for vehicles in the network
-        if self.initial_config.positions is None:
-            self.initial_config.positions, self.initial_config.lanes = \
-                self.generate_starting_positions()
+        positions, lanes = self.generate_starting_positions()
 
         # create the sumo configuration files using the generator class
         cfg_name = self.generator.generate_cfg(self.net_params,
                                                self.traffic_lights)
 
-        self.generator.make_routes(self, self.initial_config)
+        shuffle = initial_config.shuffle
+        self.generator.make_routes(self, positions, lanes, shuffle)
 
         # specify the location of the sumo configuration file
         self.cfg = self.generator.cfg_path + cfg_name
@@ -144,7 +143,7 @@ class Scenario(Serializable):
 
         Returns
         -------
-        edgestarts: list
+        edgestarts : list
             list of edge names and starting positions,
             ex: [(edge0, pos0), (edge1, pos1), ...]
         """
@@ -160,7 +159,7 @@ class Scenario(Serializable):
 
         Returns
         -------
-        intersection_edgestarts: list
+        intersection_edgestarts : list
             list of intersection names and starting positions,
             ex: [(intersection0, pos0), (intersection1, pos1), ...]
         """
@@ -175,7 +174,7 @@ class Scenario(Serializable):
 
         Returns
         -------
-        internal_edgestarts: list
+        internal_edgestarts : list
             list of internal junction names and starting positions,
             ex: [(internal0, pos0), (internal1, pos1), ...]
         """
@@ -187,12 +186,12 @@ class Scenario(Serializable):
 
         Parameters
         ----------
-        x: float
+        x : float
             absolute position in network
 
         Returns
         -------
-        edge position: tup
+        edge position : tup
             1st element: edge name (such as bottom, right, etc.)
             2nd element: relative position on edge
         """
@@ -206,14 +205,14 @@ class Scenario(Serializable):
 
         Parameters
         ----------
-        edge: str
+        edge : str
             name of the edge
-        position: float
+        position : float
             relative position on the edge
 
         Returns
         -------
-        absolute_position: float
+        absolute_position : float
             position with respect to some global reference
         """
         # if there was a collision which caused the vehicle to disappear,
@@ -239,18 +238,18 @@ class Scenario(Serializable):
 
         Parameters
         ----------
-        num_vehicles: int, optional
+        num_vehicles : int, optional
             number of vehicles to be placed on the network. If no value is
             specified, the value is collected from the vehicles class
-        kwargs: dict
+        kwargs : dict
             additional arguments that may be updated beyond initial
             configurations, such as modifying the starting position
 
         Returns
         -------
-        startpositions: list
+        startpositions : list of tuple (float, float)
             list of start positions [(edge0, pos0), (edge1, pos1), ...]
-        startlanes: list
+        startlanes : list of int
             list of start lanes
         """
         num_vehicles = num_vehicles or self.vehicles.num_vehicles
@@ -281,19 +280,19 @@ class Scenario(Serializable):
 
         Parameters
         ----------
-        initial_config: InitialConfig type
+        initial_config : InitialConfig type
             see flow/core/params.py
-        num_vehicles: int
+        num_vehicles : int
             number of vehicles to be placed on the network
-        kwargs: dict
+        kwargs : dict
             extra components, usually defined during reset to overwrite initial
             config parameters
 
         Returns
         -------
-        startpositions: list
+        startpositions : list of tuple (float, float)
             list of start positions [(edge0, pos0), (edge1, pos1), ...]
-        startlanes: list
+        startlanes : list of int
             list of start lanes
         """
         (x0, min_gap, bunching, lanes_distr, available_length,
@@ -379,19 +378,19 @@ class Scenario(Serializable):
 
         Parameters
         ----------
-        initial_config: InitialConfig type
+        initial_config : InitialConfig type
             see flow/core/params.py
-        num_vehicles: int
+        num_vehicles : int
             number of vehicles to be placed on the network
-        kwargs: dict
+        kwargs : dict
             extra components, usually defined during reset to overwrite initial
             config parameters
 
         Returns
         -------
-        startpositions: list
+        startpositions : list of tuple (float, float)
             list of start positions [(edge0, pos0), (edge1, pos1), ...]
-        startlanes: list
+        startlanes : list of int
             list of start lanes
         """
         (x0, min_gap, bunching, lanes_distr, available_length,
@@ -456,19 +455,19 @@ class Scenario(Serializable):
 
         Parameters
         ----------
-        initial_config: InitialConfig type
+        initial_config : InitialConfig type
             see flow/core/params.py
-        num_vehicles: int
+        num_vehicles : int
             number of vehicles to be placed on the network
-        kwargs: dict
+        kwargs : dict
             extra components, usually defined during reset to overwrite initial
             config parameters
 
         Returns
         -------
-        startpositions: list
+        startpositions : list of tuple (float, float)
             list of start positions [(edge0, pos0), (edge1, pos1), ...]
-        startlanes: list
+        startlanes : list of int
             list of start lanes
         """
         raise NotImplementedError
@@ -482,28 +481,28 @@ class Scenario(Serializable):
 
         Parameters
         ----------
-        initial_config: InitialConfig type
+        initial_config : InitialConfig type
             see flow/core/params.py
-        num_vehicles: int
+        num_vehicles : int
             number of vehicles to be placed on the network
-        kwargs: dict
+        kwargs : dict
             extra components, usually defined during reset to overwrite initial
             config parameters
 
         Returns
         -------
-        x0: float
+        x0 : float
             starting position of the first vehicle, in meters
-        min_gap: float
+        min_gap : float
             minimum gap between vehicles
-        bunching: float
+        bunching : float
             the amount of space freed up in the network (per lane)
-        lanes_distribution: int
+        lanes_distribution : int
             number of lanes the vehicles are supposed to be distributed over
-        available_length: float
+        available_length : float
             total available free space for vehicle to be placed, over all lanes
             within the distributable lanes, in meters
-        initial_config: InitialConfig type
+        initial_config : InitialConfig type
             modified version of the initial_config parameter
 
         Raises

--- a/tests/fast_tests/test_util.py
+++ b/tests/fast_tests/test_util.py
@@ -145,11 +145,6 @@ class TestRegistry(unittest.TestCase):
         # that this feature is in fact needed to avoid race conditions
         flow_params["sumo"].port = env.env.sumo_params.port
 
-        # TODO(ak): deal with this hack
-        flow_params["initial"].positions = \
-            env.env.scenario.initial_config.positions
-        flow_params["initial"].lanes = env.env.scenario.initial_config.lanes
-
         # check that each of the parameter match
         self.assertEqual(env.env.env_params.__dict__,
                          flow_params["env"].__dict__)
@@ -275,10 +270,6 @@ class TestRllib(unittest.TestCase):
 
         # delete the created file
         os.remove(os.path.expanduser('params.json'))
-
-        # TODO(ak): deal with this hack
-        imported_flow_params["initial"].positions = None
-        imported_flow_params["initial"].lanes = None
 
         # test that this inflows are correct
         self.assertTrue(imported_flow_params["net"].in_flows.__dict__ ==


### PR DESCRIPTION
- removed positions and lanes from `initial_config`. These attributes are modified by the generator class, and causes confusion and some bugs when trying to use the same parameters on a new task (e.g. what we do in the homework, which is all written in jupyter). This removes the need to write:
```
initial_config.lanes, initial_config.positions = None, None
```
- minor modifications to the docstrings