### PR TITLE
Include binary sumo via wheel

### DIFF
--- a/flow/envs/base_env.py
+++ b/flow/envs/base_env.py
@@ -178,9 +178,12 @@ class Env(gym.Env, Serializable):
                         time.sleep(1.0 * int(time_stamp[-6:]) / 1e6)
                         port = sumolib.miscutils.getFreeSocketPort()
 
+                script_dir = os.path.dirname(os.path.realpath(__file__))
+                sumo_binary = os.path.join(script_dir, "..", "bin", self.sumo_params.sumo_binary)
+
                 # command used to start sumo
                 sumo_call = [
-                    self.sumo_params.sumo_binary, "-c", self.scenario.cfg,
+                    sumo_binary, "-c", self.scenario.cfg,
                     "--remote-port",
                     str(port), "--step-length",
                     str(self.sim_step)

--- a/scripts/build_wheels_macos.sh
+++ b/scripts/build_wheels_macos.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Cause the script to exit if a single command fails.
+set -e
+
+# Show explicitly which commands are currently running.
+set -x
+
+# Much of this is taken from https://github.com/matthew-brett/multibuild.
+# This script uses "sudo", so you may need to type in a password a couple times.
+
+MACPYTHON_URL=https://www.python.org/ftp/python
+MACPYTHON_PY_PREFIX=/Library/Frameworks/Python.framework/Versions
+DOWNLOAD_DIR=python_downloads
+
+PY_VERSIONS=("2.7.13"
+             "3.4.4"
+             "3.5.3"
+             "3.6.1")
+PY_INSTS=("python-2.7.13-macosx10.6.pkg"
+          "python-3.4.4-macosx10.6.pkg"
+          "python-3.5.3-macosx10.6.pkg"
+          "python-3.6.1-macosx10.6.pkg")
+PY_MMS=("2.7"
+        "3.4"
+        "3.5"
+        "3.6")
+
+mkdir -p $DOWNLOAD_DIR
+mkdir -p .whl
+
+for ((i=0; i<${#PY_VERSIONS[@]}; ++i)); do
+  PY_VERSION=${PY_VERSIONS[i]}
+  PY_INST=${PY_INSTS[i]}
+  PY_MM=${PY_MMS[i]}
+
+  # Install Python.
+  INST_PATH=python_downloads/$PY_INST
+  curl $MACPYTHON_URL/$PY_VERSION/$PY_INST > $INST_PATH
+  sudo installer -pkg $INST_PATH -target /
+
+  PYTHON_EXE=$MACPYTHON_PY_PREFIX/$PY_MM/bin/python$PY_MM
+  PIP_CMD="$(dirname $PYTHON_EXE)/pip$PY_MM"
+
+  pushd /tmp
+    # Install latest version of pip to avoid brownouts
+    curl https://bootstrap.pypa.io/get-pip.py | $PYTHON_EXE
+  popd
+
+  # Setuptools on CentOS is too old to install arrow 0.9.0, therefore we upgrade.
+  $PIP_CMD install --upgrade setuptools
+  # Install setuptools_scm because otherwise when building the wheel for
+  # Python 3.6, we see an error.
+  $PIP_CMD install -q setuptools_scm==2.1.0
+  # Fix the numpy version because this will be the oldest numpy version we can
+  # support.
+  $PIP_CMD install -q numpy==1.10.4 cython==0.27.3
+  # Install wheel to avoid the error "invalid command 'bdist_wheel'".
+  $PIP_CMD install -q wheel
+  # Add the correct Python to the path and build the wheel. This is only
+  # needed so that the installation finds the cython executable.
+  INCLUDE_UI=1 PATH=$MACPYTHON_PY_PREFIX/$PY_MM/bin:$PATH $PYTHON_EXE setup.py bdist_wheel
+done

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
 # flake8: noqa
+import os
 from os.path import dirname, realpath
 from setuptools import find_packages, setup, Distribution
+import shutil
 import setuptools.command.build_ext as _build_ext
 import subprocess
 from flow.version import __version__
+
+
+flow_files = [
+    "flow/bin/sumo",
+    "flow/bin/sumo-gui"
+]
 
 
 def _read_requirements_file():
@@ -27,6 +35,19 @@ class build_ext(_build_ext.build_ext):
                 ['pip', 'install',
                  'git+https://github.com/openai/gym.git@'
                  '93d554bdbb4b2d29ff1a685158dbde93b36e3801#egg=gym'])
+
+        for filename in flow_files:
+            self.move_file(filename)
+
+    def move_file(self, filename):
+        source = filename
+        destination = os.path.join(self.build_lib, filename)
+        # Create the target directory if it doesn't already exist.
+        parent_directory = os.path.dirname(destination)
+        if not os.path.exists(parent_directory):
+            os.makedirs(parent_directory)
+        print("Copying {} to {}.".format(source, destination))
+        shutil.copy(source, destination)
 
 
 class BinaryDistribution(Distribution):


### PR DESCRIPTION
This should make it much easier to install flow by removing the "compile SUMO" step in the installation instructions.

The wheel can be built in the following way (this only needs to be done once and then the resulting wheel can be distributed for easy installation):

- First build sumo
- Drop the sumo and sumo-gui binaries into flow/flow/bin/
- Run the following in the flow (root) directory:
```
python setup.py bdist_wheel
```

The resulting wheel will be in `flow/dist/<wheelname>.whl`. It can be installed via
```
pip install <wheelname>.whl
```

For easier installation and automatically figuring out the distribution, the wheel should be uploaded to pypy.

