### PR TITLE
Added flexibility for flow naming

### DIFF
--- a/flow/core/params.py
+++ b/flow/core/params.py
@@ -532,6 +532,7 @@ class InFlows:
     def add(self,
             veh_type,
             edge,
+            name="flow",
             begin=1,
             end=2e6,
             vehs_per_hour=None,
@@ -579,7 +580,7 @@ class InFlows:
             del kwargs["vehsPerHour"]
 
         new_inflow = {
-            "name": "flow_%d" % self.num_flows,
+            "name": "%s_%d" % (name, self.num_flows),
             "vtype": veh_type,
             "route": "route" + edge,
             "end": end


### PR DESCRIPTION
Resolves #97 This allows for customizable flow names. I add a new optional name parameter to the Inflow class' add function, which defaults to "flow" (what it was originally). Inflow experiments run as expected with this change.