### PR TITLE
added warning about inflows

### DIFF
--- a/examples/rllab/green_wave.py
+++ b/examples/rllab/green_wave.py
@@ -47,7 +47,7 @@ def get_flow_params(v_enter, vehs_per_hour, col_num, row_num,
             departSpeed=v_enter)
 
     net_params = NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params=additional_net_params)
 

--- a/examples/rllab/stabilizing_highway.py
+++ b/examples/rllab/stabilizing_highway.py
@@ -98,7 +98,7 @@ def run_task(_):
     additional_net_params["highway_lanes"] = 1
     additional_net_params["pre_merge_length"] = 500
     net_params = NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params=additional_net_params)
 

--- a/examples/rllab/velocity_bottleneck.py
+++ b/examples/rllab/velocity_bottleneck.py
@@ -103,7 +103,7 @@ if not DISABLE_RAMP_METER:
 
 additional_net_params = {"scaling": SCALING}
 net_params = NetParams(
-    in_flows=inflow,
+    inflows=inflow,
     no_internal_links=False,
     additional_params=additional_net_params)
 

--- a/examples/rllib/green_wave.py
+++ b/examples/rllib/green_wave.py
@@ -51,7 +51,7 @@ def get_flow_params(col_num, row_num, additional_net_params):
             departSpeed=20)
 
     net_params = NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params=additional_net_params)
 

--- a/examples/rllib/stabilizing_highway.py
+++ b/examples/rllib/stabilizing_highway.py
@@ -117,7 +117,7 @@ flow_params = dict(
     # network-related parameters (see flow.core.params.NetParams and the
     # scenario's documentation or ADDITIONAL_NET_PARAMS component)
     net=NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params=additional_net_params,
     ),

--- a/examples/rllib/velocity_bottleneck.py
+++ b/examples/rllib/velocity_bottleneck.py
@@ -92,7 +92,7 @@ if not DISABLE_RAMP_METER:
 
 additional_net_params = {"scaling": SCALING}
 net_params = NetParams(
-    in_flows=inflow,
+    inflows=inflow,
     no_internal_links=False,
     additional_params=additional_net_params)
 
@@ -128,7 +128,7 @@ flow_params = dict(
     # network-related parameters (see flow.core.params.NetParams and the
     # scenario's documentation or ADDITIONAL_NET_PARAMS component)
     net=NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params=additional_net_params,
     ),

--- a/examples/sumo/bay_bridge.py
+++ b/examples/sumo/bay_bridge.py
@@ -159,7 +159,7 @@ def bay_bridge_example(sumo_binary=None,
             departLane="0",
             departSpeed=20)  # no data for this
 
-    net_params = NetParams(in_flows=inflow, no_internal_links=False)
+    net_params = NetParams(inflows=inflow, no_internal_links=False)
     net_params.netfile = NETFILE
 
     # download the netfile from AWS

--- a/examples/sumo/bay_bridge_toll.py
+++ b/examples/sumo/bay_bridge_toll.py
@@ -85,7 +85,7 @@ def bay_bridge_bottleneck_example(sumo_binary=None, use_traffic_lights=False):
         departSpeed=10)
 
     net_params = NetParams(
-        in_flows=inflow, no_internal_links=False, netfile=NETFILE)
+        inflows=inflow, no_internal_links=False, netfile=NETFILE)
 
     # download the netfile from AWS
     if use_traffic_lights:

--- a/examples/sumo/bottleneck.py
+++ b/examples/sumo/bottleneck.py
@@ -82,7 +82,7 @@ def bottleneck_example(flow_rate, horizon, sumo_binary=None):
 
     additional_net_params = {"scaling": SCALING}
     net_params = NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params=additional_net_params)
 

--- a/examples/sumo/highway.py
+++ b/examples/sumo/highway.py
@@ -59,7 +59,7 @@ def highway_example(sumo_binary=None):
 
     additional_net_params = ADDITIONAL_NET_PARAMS.copy()
     net_params = NetParams(
-        in_flows=inflow, additional_params=additional_net_params)
+        inflows=inflow, additional_params=additional_net_params)
 
     initial_config = InitialConfig(spacing="uniform", shuffle=True)
 

--- a/examples/sumo/merge.py
+++ b/examples/sumo/merge.py
@@ -76,7 +76,7 @@ def merge_example(sumo_binary=None):
     additional_net_params["highway_lanes"] = 1
     additional_net_params["pre_merge_length"] = 500
     net_params = NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params=additional_net_params)
 

--- a/flow/benchmarks/baselines/bottleneck0.py
+++ b/flow/benchmarks/baselines/bottleneck0.py
@@ -81,7 +81,7 @@ def bottleneck0_baseline(num_runs, sumo_binary="sumo-gui"):
         traffic_lights.add(node_id="3")
 
     additional_net_params = {"scaling": SCALING}
-    net_params = NetParams(in_flows=inflow,
+    net_params = NetParams(inflows=inflow,
                            no_internal_links=False,
                            additional_params=additional_net_params)
 

--- a/flow/benchmarks/baselines/bottleneck1.py
+++ b/flow/benchmarks/baselines/bottleneck1.py
@@ -81,7 +81,7 @@ def bottleneck1_baseline(num_runs, sumo_binary="sumo-gui"):
         traffic_lights.add(node_id="3")
 
     additional_net_params = {"scaling": SCALING}
-    net_params = NetParams(in_flows=inflow,
+    net_params = NetParams(inflows=inflow,
                            no_internal_links=False,
                            additional_params=additional_net_params)
 

--- a/flow/benchmarks/baselines/bottleneck2.py
+++ b/flow/benchmarks/baselines/bottleneck2.py
@@ -81,7 +81,7 @@ def bottleneck2_baseline(num_runs, sumo_binary="sumo-gui"):
         traffic_lights.add(node_id="3")
 
     additional_net_params = {"scaling": SCALING}
-    net_params = NetParams(in_flows=inflow,
+    net_params = NetParams(inflows=inflow,
                            no_internal_links=False,
                            additional_params=additional_net_params)
 

--- a/flow/benchmarks/baselines/grid0.py
+++ b/flow/benchmarks/baselines/grid0.py
@@ -93,7 +93,7 @@ def grid0_baseline(num_runs, sumo_binary="sumo-gui"):
                      programID=1)
 
     net_params = NetParams(
-            in_flows=inflow,
+            inflows=inflow,
             no_internal_links=False,
             additional_params={
                 "speed_limit": V_ENTER + 5,

--- a/flow/benchmarks/baselines/grid1.py
+++ b/flow/benchmarks/baselines/grid1.py
@@ -93,7 +93,7 @@ def grid1_baseline(num_runs, sumo_binary="sumo-gui"):
                      programID=1)
 
     net_params = NetParams(
-            in_flows=inflow,
+            inflows=inflow,
             no_internal_links=False,
             additional_params={
                 "speed_limit": V_ENTER + 5,

--- a/flow/benchmarks/baselines/merge012.py
+++ b/flow/benchmarks/baselines/merge012.py
@@ -85,7 +85,7 @@ def merge_baseline(num_runs, sumo_binary="sumo-gui"):
     initial_config = InitialConfig()
 
     net_params = NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params=additional_net_params,
     )

--- a/flow/benchmarks/bottleneck0.py
+++ b/flow/benchmarks/bottleneck0.py
@@ -83,7 +83,7 @@ if not DISABLE_RAMP_METER:
 
 additional_net_params = {"scaling": SCALING}
 net_params = NetParams(
-    in_flows=inflow,
+    inflows=inflow,
     no_internal_links=False,
     additional_params=additional_net_params)
 
@@ -119,7 +119,7 @@ flow_params = dict(
     # network-related parameters (see flow.core.params.NetParams and the
     # scenario's documentation or ADDITIONAL_NET_PARAMS component)
     net=NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params=additional_net_params,
     ),

--- a/flow/benchmarks/bottleneck1.py
+++ b/flow/benchmarks/bottleneck1.py
@@ -84,7 +84,7 @@ if not DISABLE_RAMP_METER:
 
 additional_net_params = {"scaling": SCALING}
 net_params = NetParams(
-    in_flows=inflow,
+    inflows=inflow,
     no_internal_links=False,
     additional_params=additional_net_params)
 
@@ -120,7 +120,7 @@ flow_params = dict(
     # network-related parameters (see flow.core.params.NetParams and the
     # scenario's documentation or ADDITIONAL_NET_PARAMS component)
     net=NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params=additional_net_params,
     ),

--- a/flow/benchmarks/bottleneck2.py
+++ b/flow/benchmarks/bottleneck2.py
@@ -84,7 +84,7 @@ if not DISABLE_RAMP_METER:
 
 additional_net_params = {"scaling": SCALING}
 net_params = NetParams(
-    in_flows=inflow,
+    inflows=inflow,
     no_internal_links=False,
     additional_params=additional_net_params)
 
@@ -120,7 +120,7 @@ flow_params = dict(
     # network-related parameters (see flow.core.params.NetParams and the
     # scenario's documentation or ADDITIONAL_NET_PARAMS component)
     net=NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params=additional_net_params,
     ),

--- a/flow/benchmarks/grid0.py
+++ b/flow/benchmarks/grid0.py
@@ -95,7 +95,7 @@ flow_params = dict(
     # network-related parameters (see flow.core.params.NetParams and the
     # scenario's documentation or ADDITIONAL_NET_PARAMS component)
     net=NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params={
             "speed_limit": V_ENTER + 5,

--- a/flow/benchmarks/grid1.py
+++ b/flow/benchmarks/grid1.py
@@ -95,7 +95,7 @@ flow_params = dict(
     # network-related parameters (see flow.core.params.NetParams and the
     # scenario's documentation or ADDITIONAL_NET_PARAMS component)
     net=NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params={
             "speed_limit": V_ENTER + 5,

--- a/flow/benchmarks/merge0.py
+++ b/flow/benchmarks/merge0.py
@@ -104,7 +104,7 @@ flow_params = dict(
     # network-related parameters (see flow.core.params.NetParams and the
     # scenario's documentation or ADDITIONAL_NET_PARAMS component)
     net=NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params=additional_net_params,
     ),

--- a/flow/benchmarks/merge1.py
+++ b/flow/benchmarks/merge1.py
@@ -104,7 +104,7 @@ flow_params = dict(
     # network-related parameters (see flow.core.params.NetParams and the
     # scenario's documentation or ADDITIONAL_NET_PARAMS component)
     net=NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params=additional_net_params,
     ),

--- a/flow/benchmarks/merge2.py
+++ b/flow/benchmarks/merge2.py
@@ -104,7 +104,7 @@ flow_params = dict(
     # network-related parameters (see flow.core.params.NetParams and the
     # scenario's documentation or ADDITIONAL_NET_PARAMS component)
     net=NetParams(
-        in_flows=inflow,
+        inflows=inflow,
         no_internal_links=False,
         additional_params=additional_net_params,
     ),

--- a/flow/core/generator.py
+++ b/flow/core/generator.py
@@ -397,8 +397,8 @@ class Generator(Serializable):
                     departLane=str(lane)))
 
         # add the in-flows from various edges to the xml file
-        if self.net_params.in_flows is not None:
-            total_inflows = self.net_params.in_flows.get()
+        if self.net_params.inflows is not None:
+            total_inflows = self.net_params.inflows.get()
             for inflow in total_inflows:
                 for key in inflow:
                     if not isinstance(inflow[key], str):

--- a/flow/core/params.py
+++ b/flow/core/params.py
@@ -165,7 +165,7 @@ class NetParams:
 
     def __init__(self,
                  no_internal_links=True,
-                 in_flows=None,
+                 inflows=None,
                  osm_path=None,
                  netfile=None,
                  additional_params=None):
@@ -176,7 +176,7 @@ class NetParams:
         no_internal_links : bool, optional
             determines whether the space between edges is finite. Important
             when using networks with intersections; default is False
-        in_flows : InFlows type, optional
+        inflows : InFlows type, optional
             specifies the inflows of specific edges and the types of vehicles
             entering the network from these edges
         osm_path : str, optional
@@ -193,10 +193,10 @@ class NetParams:
             what is needed
         """
         self.no_internal_links = no_internal_links
-        if in_flows is None:
-            self.in_flows = InFlows()
+        if inflows is None:
+            self.inflows = InFlows()
         else:
-            self.in_flows = in_flows
+            self.inflows = inflows
         self.osm_path = osm_path
         self.netfile = netfile
         self.additional_params = additional_params or {}

--- a/flow/core/params.py
+++ b/flow/core/params.py
@@ -193,7 +193,10 @@ class NetParams:
             what is needed
         """
         self.no_internal_links = no_internal_links
-        self.in_flows = in_flows
+        if in_flows is None:
+            self.in_flows = InFlows()
+        else:
+            self.in_flows = in_flows
         self.osm_path = osm_path
         self.netfile = netfile
         self.additional_params = additional_params or {}

--- a/flow/core/util.py
+++ b/flow/core/util.py
@@ -111,8 +111,8 @@ def eval_net_params(flow_params):
     better_params = flow_params.copy()
     inflow = InFlows()
     new_inflow_list = []
-    if 'in_flows' in flow_params['net']:
-        inflow_obj = flow_params['net']['in_flows']['_InFlows__flows']
+    if 'inflows' in flow_params['net']:
+        inflow_obj = flow_params['net']['inflows']['_InFlows__flows']
         for obj in inflow_obj:
             temp = {}
             for key in obj.keys():
@@ -127,7 +127,7 @@ def eval_net_params(flow_params):
                     temp[key] = obj[key]
             new_inflow_list.append(temp)
         [inflow.add(**inflow_i) for inflow_i in new_inflow_list]
-        better_params['net']['in_flows'] = inflow
+        better_params['net']['inflows'] = inflow
 
     return better_params['net']
 

--- a/flow/envs/base_env.py
+++ b/flow/envs/base_env.py
@@ -9,6 +9,7 @@ import time
 import traceback
 import numpy as np
 import random
+import warnings
 
 import traci
 from traci import constants as tc
@@ -486,6 +487,21 @@ class Env(gym.Env, Serializable):
         """
         # reset the time counter
         self.time_counter = 0
+
+        # warn about not using restart_instance when using inflows
+        if len(self.scenario.net_params.in_flows.get()) > 0 and \
+                not self.sumo_params.restart_instance:
+            print(
+                "**********************************************************\n"
+                "**********************************************************\n"
+                "**********************************************************\n"
+                "WARNING: Inflows will cause computational performance to\n"
+                "significantly decrease after large number of rollouts. In \n"
+                "order to avoid this, set SumoParams(restart_instance=True).\n"
+                "**********************************************************\n"
+                "**********************************************************\n"
+                "**********************************************************"
+            )
 
         if self.sumo_params.restart_instance or self.step_counter > 2e6:
             self.step_counter = 0

--- a/flow/envs/base_env.py
+++ b/flow/envs/base_env.py
@@ -488,7 +488,7 @@ class Env(gym.Env, Serializable):
         self.time_counter = 0
 
         # warn about not using restart_instance when using inflows
-        if len(self.scenario.net_params.in_flows.get()) > 0 and \
+        if len(self.scenario.net_params.inflows.get()) > 0 and \
                 not self.sumo_params.restart_instance:
             print(
                 "**********************************************************\n"

--- a/flow/envs/base_env.py
+++ b/flow/envs/base_env.py
@@ -9,7 +9,6 @@ import time
 import traceback
 import numpy as np
 import random
-import warnings
 
 import traci
 from traci import constants as tc

--- a/flow/envs/bottleneck_env.py
+++ b/flow/envs/bottleneck_env.py
@@ -878,7 +878,7 @@ class DesiredVelocityEnv(BottleneckEnv):
 
                     additional_net_params = {"scaling": self.scaling}
                     net_params = NetParams(
-                        in_flows=inflow,
+                        inflows=inflow,
                         no_internal_links=False,
                         additional_params=additional_net_params)
 

--- a/flow/utils/rllib.py
+++ b/flow/utils/rllib.py
@@ -109,9 +109,9 @@ def get_flow_params(config):
 
     net = NetParams()
     net.__dict__ = flow_params["net"].copy()
-    net.in_flows = InFlows()
-    if flow_params["net"]["in_flows"]:
-        net.in_flows.__dict__ = flow_params["net"]["in_flows"].copy()
+    net.inflows = InFlows()
+    if flow_params["net"]["inflows"]:
+        net.inflows.__dict__ = flow_params["net"]["inflows"].copy()
 
     env = EnvParams()
     env.__dict__ = flow_params["env"].copy()

--- a/tests/fast_tests/test_collisions.py
+++ b/tests/fast_tests/test_collisions.py
@@ -106,7 +106,7 @@ class TestCollisions(unittest.TestCase):
 
         net_params = NetParams(
             no_internal_links=False,
-            in_flows=inflows,
+            inflows=inflows,
             additional_params=additional_net_params)
 
         self.env, self.scenario = grid_mxn_exp_setup(

--- a/tests/fast_tests/test_util.py
+++ b/tests/fast_tests/test_util.py
@@ -231,7 +231,7 @@ class TestRllib(unittest.TestCase):
                 },
             ),
             net=NetParams(
-                in_flows=inflow,
+                inflows=inflow,
                 no_internal_links=False,
                 additional_params={
                     "merge_length": 100,
@@ -272,11 +272,11 @@ class TestRllib(unittest.TestCase):
         os.remove(os.path.expanduser('params.json'))
 
         # test that this inflows are correct
-        self.assertTrue(imported_flow_params["net"].in_flows.__dict__ ==
-                        flow_params["net"].in_flows.__dict__)
+        self.assertTrue(imported_flow_params["net"].inflows.__dict__ ==
+                        flow_params["net"].inflows.__dict__)
 
-        imported_flow_params["net"].in_flows = None
-        flow_params["net"].in_flows = None
+        imported_flow_params["net"].inflows = None
+        flow_params["net"].inflows = None
 
         # make sure the rest of the imported flow_params match the originals
         self.assertTrue(imported_flow_params["env"].__dict__ == flow_params[

--- a/tests/setup_scripts.py
+++ b/tests/setup_scripts.py
@@ -582,7 +582,7 @@ def setup_bottlenecks(sumo_params=None,
     if net_params is None:
         additional_net_params = {"scaling": scaling}
         net_params = NetParams(
-            in_flows=inflow,
+            inflows=inflow,
             no_internal_links=False,
             additional_params=additional_net_params)
 

--- a/tutorials/tutorial09_inflows.ipynb
+++ b/tutorials/tutorial09_inflows.ipynb
@@ -150,7 +150,7 @@
     "# we choose to make the main highway slightly longer\n",
     "additional_net_params[\"pre_merge_length\"] = 500\n",
     "\n",
-    "net_params = NetParams(in_flows=inflow,  # our inflows\n",
+    "net_params = NetParams(inflows=inflow,  # our inflows\n",
     "                       no_internal_links=False,\n",
     "                       additional_params=additional_net_params)"
    ]


### PR DESCRIPTION
resolves #59 by adding an intrusive warning after every reset about using inflows without `restart_instance` set to True. Looks something like this:

```
Loading configuration... done.
Success.
Loading configuration... done.
**********************************************************
**********************************************************
**********************************************************
WARNING: Inflows will cause computational performance to
significantly decrease after large number of rollouts. In 
order to avoid this, set SumoParams(restart_instance=True).
**********************************************************
**********************************************************
**********************************************************
Round 0, return: 13.066371609964094
**********************************************************
**********************************************************
**********************************************************
WARNING: Inflows will cause computational performance to
significantly decrease after large number of rollouts. In 
order to avoid this, set SumoParams(restart_instance=True).
**********************************************************
**********************************************************
**********************************************************
Round 1, return: 14.110232659070526
**********************************************************
**********************************************************
**********************************************************
WARNING: Inflows will cause computational performance to
significantly decrease after large number of rollouts. In 
order to avoid this, set SumoParams(restart_instance=True).
**********************************************************
**********************************************************
**********************************************************
Round 2, return: 14.517916889477418
**********************************************************
**********************************************************
**********************************************************
WARNING: Inflows will cause computational performance to
significantly decrease after large number of rollouts. In 
order to avoid this, set SumoParams(restart_instance=True).
**********************************************************
**********************************************************
**********************************************************
Round 3, return: 14.559529119986474
**********************************************************
**********************************************************
**********************************************************
WARNING: Inflows will cause computational performance to
significantly decrease after large number of rollouts. In 
order to avoid this, set SumoParams(restart_instance=True).
**********************************************************
**********************************************************
**********************************************************
Round 4, return: 14.781739529547469
**********************************************************
**********************************************************
**********************************************************
WARNING: Inflows will cause computational performance to
significantly decrease after large number of rollouts. In 
order to avoid this, set SumoParams(restart_instance=True).
**********************************************************
**********************************************************
**********************************************************
Round 5, return: 14.830213833928935
**********************************************************
**********************************************************
**********************************************************
WARNING: Inflows will cause computational performance to
significantly decrease after large number of rollouts. In 
order to avoid this, set SumoParams(restart_instance=True).
**********************************************************
**********************************************************
**********************************************************
Round 6, return: 14.919557372953372
**********************************************************
**********************************************************
**********************************************************
WARNING: Inflows will cause computational performance to
significantly decrease after large number of rollouts. In 
order to avoid this, set SumoParams(restart_instance=True).
**********************************************************
**********************************************************
**********************************************************
Round 7, return: 14.437867022540612
**********************************************************
**********************************************************
**********************************************************
WARNING: Inflows will cause computational performance to
significantly decrease after large number of rollouts. In 
order to avoid this, set SumoParams(restart_instance=True).
**********************************************************
**********************************************************
**********************************************************
Round 8, return: 14.875250659072394
**********************************************************
**********************************************************
**********************************************************
WARNING: Inflows will cause computational performance to
significantly decrease after large number of rollouts. In 
order to avoid this, set SumoParams(restart_instance=True).
**********************************************************
**********************************************************
**********************************************************
Round 9, return: 14.606470448185524
Average, std return: 14.470514914472682, 0.5218080314950918
Average, std speed: 12.620559341317108, 0.2995073070087741
```