### PR TITLE
Changed the default value of detector gap to resolve the warning

### DIFF
--- a/flow/core/traffic_lights.py
+++ b/flow/core/traffic_lights.py
@@ -5,7 +5,7 @@ import traci.constants as tc
 # DEFAULTS
 PROGRAM_ID = 1
 MAX_GAP = 3.0
-DETECTOR_GAP = 0.8
+DETECTOR_GAP = 0.6
 SHOW_DETECTORS = True
 
 


### PR DESCRIPTION
Closes issue #44.  I changed the default value of the detector gap to resolve the warning "Warning: At actuated tlLogic 'center2', minDur 3.00 is too short to short for detector gap of 24.50m." I want to keep the default phase minDur for yellow phases at 3s, because 3s is a standard yellow light phase time for roads at 30 mph.