### PR TITLE
pointed at the flow-project version of ray

### DIFF
--- a/docs/source/flow_setup.rst
+++ b/docs/source/flow_setup.rst
@@ -270,7 +270,7 @@ g. Ray/RLlib (optional)
 =======================
 RLlib is another RL library that has been extensively tested on the Flow
 repository. 
-First visit <https://github.com/eugenevinitsky/ray/blob/master/doc/source/installation.rst> and
+First visit <https://github.com/flow-project/ray/blob/master/doc/source/installation.rst> and
 install the required packages. Do NOT `pip install ray`.
 
 The installation process for this library is as follows:
@@ -278,7 +278,7 @@ The installation process for this library is as follows:
 ::
 
     cd ~
-    git clone https://github.com/eugenevinitsky/ray.git
+    git clone https://github.com/flow-project/ray.git
     cd ray/python/
     python setup.py develop
 


### PR DESCRIPTION
Instruction should point to the flow-project version of ray rather than my personal version of ray