### PR TITLE
point travis at correct ray repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_install:
 
   # Copy over local rllib changes (testing branch)
   - pushd $HOME/build/flow-project
-  -     git clone https://github.com/eugenevinitsky/ray.git
+  -     git clone https://github.com/flow-project/ray.git
   -     cd ray && git fetch && git checkout master && cd ..
   -     pushd ray
   -         RAY_SITE_DIR=`python -c "import ray; print(ray.__path__[0])"`


### PR DESCRIPTION
Travis is still pointed at eugenevinitsky/ray which prevents us from catching errors and incompatibilities