### PR TITLE
extended unit test coverage of utils

### DIFF
--- a/tests/fast_tests/test_util.py
+++ b/tests/fast_tests/test_util.py
@@ -178,6 +178,8 @@ class TestRllib(unittest.TestCase):
         vehicles.add(
             veh_id="human",
             acceleration_controller=(IDMController, {}),
+            # for testing coverage purposes, we add a routing controller
+            routing_controller=(ContinuousRouter, {}),
             speed_mode="no_collide",
             num_vehicles=5)
         vehicles.add(


### PR DESCRIPTION
the serialization of routing controllers for RLlib experiments was not being tested, so I added a routing controller to the `flow_params` dict we are using to test `get_flow_params`