### PR TITLE
added benchmark flow_params to the baseline simulations

### DIFF
--- a/flow/benchmarks/baselines/bottleneck0.py
+++ b/flow/benchmarks/baselines/bottleneck0.py
@@ -37,7 +37,7 @@ def bottleneck0_baseline(num_runs, render=True):
     initial_config = flow_params.get('initial', InitialConfig())
     traffic_lights = flow_params.get('tls', TrafficLights())
 
-    # remove autonomous vehicles
+    # we want no autonomous vehicles in the simulation
     vehicles = Vehicles()
     vehicles.add(veh_id='human',
                  speed_mode=9,
@@ -45,7 +45,7 @@ def bottleneck0_baseline(num_runs, render=True):
                  lane_change_mode=0,
                  num_vehicles=1 * SCALING)
 
-    # modify the inflows to only include human vehicles
+    # only include human vehicles in inflows
     flow_rate = 1900 * SCALING
     inflow = InFlows()
     inflow.add(veh_type='human', edge='1',

--- a/flow/benchmarks/baselines/bottleneck0.py
+++ b/flow/benchmarks/baselines/bottleneck0.py
@@ -5,7 +5,7 @@ Baseline is no AVs.
 
 import numpy as np
 from flow.core.experiment import SumoExperiment
-from flow.core.params import InitialConfig
+from flow.core.params import InitialConfig, InFlows
 from flow.core.vehicles import Vehicles
 from flow.core.traffic_lights import TrafficLights
 from flow.controllers import ContinuousRouter
@@ -42,6 +42,14 @@ def bottleneck0_baseline(num_runs, render=True):
                  routing_controller=(ContinuousRouter, {}),
                  lane_change_mode=0,
                  num_vehicles=1 * SCALING)
+
+    # modify the inflows to only include human vehicles
+    flow_rate = 1900 * SCALING
+    inflow = InFlows()
+    inflow.add(veh_type="human", edge="1",
+               vehs_per_hour=flow_rate,
+               departLane="random", departSpeed=10)
+    net_params.inflows = inflow
 
     # modify the rendering to match what is requested
     sumo_params.render = render

--- a/flow/benchmarks/baselines/bottleneck0.py
+++ b/flow/benchmarks/baselines/bottleneck0.py
@@ -54,6 +54,9 @@ def bottleneck0_baseline(num_runs, render=True):
     # modify the rendering to match what is requested
     sumo_params.render = render
 
+    # set the evaluation flag to True
+    env_params.evaluate = True
+
     # import the scenario class
     module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
     scenario_class = getattr(module, flow_params["scenario"])

--- a/flow/benchmarks/baselines/bottleneck0.py
+++ b/flow/benchmarks/baselines/bottleneck0.py
@@ -3,24 +3,13 @@
 Baseline is no AVs.
 """
 
-from flow.core.params import SumoParams, EnvParams, InitialConfig, NetParams, \
-    InFlows
-from flow.core.traffic_lights import TrafficLights
-from flow.core.vehicles import Vehicles
-from flow.controllers import ContinuousRouter
-from flow.envs.bottleneck_env import DesiredVelocityEnv
-from flow.core.experiment import SumoExperiment
-from flow.scenarios.bottleneck import BottleneckScenario
 import numpy as np
-
-# time horizon of a single rollout
-HORIZON = 1000
-
-SCALING = 1
-NUM_LANES = 4 * SCALING  # number of lanes in the widest highway
-DISABLE_TB = True
-DISABLE_RAMP_METER = True
-AV_FRAC = 0.10
+from flow.core.experiment import SumoExperiment
+from flow.core.params import InitialConfig
+from flow.core.vehicles import Vehicles
+from flow.core.traffic_lights import TrafficLights
+from flow.controllers import ContinuousRouter
+from flow.benchmarks.bottleneck0 import flow_params, SCALING
 
 
 def bottleneck0_baseline(num_runs, render=True):
@@ -39,6 +28,14 @@ def bottleneck0_baseline(num_runs, render=True):
         SumoExperiment
             class needed to run simulations
     """
+    exp_tag = flow_params["exp_tag"]
+    sumo_params = flow_params["sumo"]
+    env_params = flow_params["env"]
+    net_params = flow_params["net"]
+    initial_config = flow_params.get("initial", InitialConfig())
+    traffic_lights = flow_params.get("tls", TrafficLights())
+
+    # remove autonomous vehicles
     vehicles = Vehicles()
     vehicles.add(veh_id="human",
                  speed_mode=9,
@@ -46,83 +43,38 @@ def bottleneck0_baseline(num_runs, render=True):
                  lane_change_mode=0,
                  num_vehicles=1 * SCALING)
 
-    controlled_segments = [("1", 1, False), ("2", 2, True), ("3", 2, True),
-                           ("4", 2, True), ("5", 1, False)]
-    num_observed_segments = [("1", 1), ("2", 3), ("3", 3),
-                             ("4", 3), ("5", 1)]
-    additional_env_params = {
-        "target_velocity": 40,
-        "disable_tb": True,
-        "disable_ramp_metering": True,
-        "controlled_segments": controlled_segments,
-        "symmetric": False,
-        "observed_segments": num_observed_segments,
-        "reset_inflow": False,
-        "lane_change_duration": 5,
-        "max_accel": 3,
-        "max_decel": 3,
-        "inflow_range": [1000, 2000]
-    }
+    # modify the rendering to match what is requested
+    sumo_params.render = render
 
-    # flow rate
-    flow_rate = 1900 * SCALING
+    # import the scenario class
+    module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
+    scenario_class = getattr(module, flow_params["scenario"])
 
-    # percentage of flow coming out of each lane
-    inflow = InFlows()
-    inflow.add(veh_type="human", edge="1",
-               vehs_per_hour=flow_rate,
-               departLane="random", departSpeed=10)
-
-    traffic_lights = TrafficLights()
-    if not DISABLE_TB:
-        traffic_lights.add(node_id="2")
-    if not DISABLE_RAMP_METER:
-        traffic_lights.add(node_id="3")
-
-    additional_net_params = {"scaling": SCALING}
-    net_params = NetParams(inflows=inflow,
-                           no_internal_links=False,
-                           additional_params=additional_net_params)
-
-    sumo_params = SumoParams(
-        sim_step=0.5,
-        render=render,
-        print_warnings=False,
-        restart_instance=False,
+    # create the scenario object
+    scenario = scenario_class(
+        name=exp_tag,
+        vehicles=vehicles,
+        net_params=net_params,
+        initial_config=initial_config,
+        traffic_lights=traffic_lights
     )
 
-    env_params = EnvParams(
-        evaluate=True,  # Set to True to evaluate traffic metrics
-        warmup_steps=40,
-        sims_per_step=1,
-        horizon=HORIZON,
-        additional_params=additional_env_params,
-    )
+    # import the environment class
+    module = __import__("flow.envs", fromlist=[flow_params["env_name"]])
+    env_class = getattr(module, flow_params["env_name"])
 
-    initial_config = InitialConfig(
-        spacing="uniform",
-        min_gap=5,
-        lanes_distribution=float("inf"),
-        edges_distribution=["2", "3", "4", "5"],
-    )
-
-    scenario = BottleneckScenario(name="bay_bridge_toll",
-                                  vehicles=vehicles,
-                                  net_params=net_params,
-                                  initial_config=initial_config,
-                                  traffic_lights=traffic_lights)
-
-    env = DesiredVelocityEnv(env_params, sumo_params, scenario)
+    # create the environment object
+    env = env_class(env_params, sumo_params, scenario)
 
     exp = SumoExperiment(env, scenario)
 
-    results = exp.run(num_runs, HORIZON)
+    results = exp.run(num_runs, env_params.horizon)
     return np.mean(results["returns"]), np.std(results["returns"])
 
 
 if __name__ == "__main__":
     runs = 2  # number of simulations to average over
-    mean, std = bottleneck0_baseline(num_runs=runs, render=False)
+    mean, std = bottleneck0_baseline(num_runs=runs, render=True)
 
     print('---------')
     print('The average outflow, std. deviation over 500 seconds '

--- a/flow/benchmarks/baselines/bottleneck0.py
+++ b/flow/benchmarks/baselines/bottleneck0.py
@@ -5,7 +5,8 @@ Baseline is no AVs.
 
 import numpy as np
 from flow.core.experiment import SumoExperiment
-from flow.core.params import InitialConfig, InFlows
+from flow.core.params import InitialConfig
+from flow.core.params import InFlows
 from flow.core.vehicles import Vehicles
 from flow.core.traffic_lights import TrafficLights
 from flow.controllers import ContinuousRouter
@@ -28,12 +29,12 @@ def bottleneck0_baseline(num_runs, render=True):
         SumoExperiment
             class needed to run simulations
     """
-    exp_tag = flow_params["exp_tag"]
-    sumo_params = flow_params["sumo"]
-    env_params = flow_params["env"]
-    net_params = flow_params["net"]
-    initial_config = flow_params.get("initial", InitialConfig())
-    traffic_lights = flow_params.get("tls", TrafficLights())
+    exp_tag = flow_params['exp_tag']
+    sumo_params = flow_params['sumo']
+    env_params = flow_params['env']
+    net_params = flow_params['net']
+    initial_config = flow_params.get('initial', InitialConfig())
+    traffic_lights = flow_params.get('tls', TrafficLights())
 
     # remove autonomous vehicles
     vehicles = Vehicles()
@@ -46,9 +47,9 @@ def bottleneck0_baseline(num_runs, render=True):
     # modify the inflows to only include human vehicles
     flow_rate = 1900 * SCALING
     inflow = InFlows()
-    inflow.add(veh_type="human", edge="1",
+    inflow.add(veh_type='human', edge='1',
                vehs_per_hour=flow_rate,
-               departLane="random", departSpeed=10)
+               departLane='random', departSpeed=10)
     net_params.inflows = inflow
 
     # modify the rendering to match what is requested
@@ -58,8 +59,8 @@ def bottleneck0_baseline(num_runs, render=True):
     env_params.evaluate = True
 
     # import the scenario class
-    module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
-    scenario_class = getattr(module, flow_params["scenario"])
+    module = __import__('flow.scenarios', fromlist=[flow_params['scenario']])
+    scenario_class = getattr(module, flow_params['scenario'])
 
     # create the scenario object
     scenario = scenario_class(
@@ -71,8 +72,8 @@ def bottleneck0_baseline(num_runs, render=True):
     )
 
     # import the environment class
-    module = __import__("flow.envs", fromlist=[flow_params["env_name"]])
-    env_class = getattr(module, flow_params["env_name"])
+    module = __import__('flow.envs', fromlist=[flow_params['env_name']])
+    env_class = getattr(module, flow_params['env_name'])
 
     # create the environment object
     env = env_class(env_params, sumo_params, scenario)
@@ -80,10 +81,10 @@ def bottleneck0_baseline(num_runs, render=True):
     exp = SumoExperiment(env, scenario)
 
     results = exp.run(num_runs, env_params.horizon)
-    return np.mean(results["returns"]), np.std(results["returns"])
+    return np.mean(results['returns']), np.std(results['returns'])
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     runs = 2  # number of simulations to average over
     mean, std = bottleneck0_baseline(num_runs=runs, render=True)
 

--- a/flow/benchmarks/baselines/bottleneck1.py
+++ b/flow/benchmarks/baselines/bottleneck1.py
@@ -37,7 +37,7 @@ def bottleneck1_baseline(num_runs, render=True):
     initial_config = flow_params.get('initial', InitialConfig())
     traffic_lights = flow_params.get('tls', TrafficLights())
 
-    # remove autonomous vehicles
+    # we want no autonomous vehicles in the simulation
     vehicles = Vehicles()
     vehicles.add(veh_id='human',
                  speed_mode=9,
@@ -45,7 +45,7 @@ def bottleneck1_baseline(num_runs, render=True):
                  lane_change_mode=1621,
                  num_vehicles=1 * SCALING)
 
-    # modify the inflows to only include human vehicles
+    # only include human vehicles in inflows
     flow_rate = 1900 * SCALING
     inflow = InFlows()
     inflow.add(veh_type='human', edge='1',

--- a/flow/benchmarks/baselines/bottleneck1.py
+++ b/flow/benchmarks/baselines/bottleneck1.py
@@ -5,7 +5,7 @@ Baseline is no AVs.
 
 import numpy as np
 from flow.core.experiment import SumoExperiment
-from flow.core.params import InitialConfig
+from flow.core.params import InitialConfig, InFlows
 from flow.core.vehicles import Vehicles
 from flow.core.traffic_lights import TrafficLights
 from flow.controllers import ContinuousRouter
@@ -42,6 +42,14 @@ def bottleneck1_baseline(num_runs, render=True):
                  routing_controller=(ContinuousRouter, {}),
                  lane_change_mode=1621,
                  num_vehicles=1 * SCALING)
+
+    # modify the inflows to only include human vehicles
+    flow_rate = 1900 * SCALING
+    inflow = InFlows()
+    inflow.add(veh_type="human", edge="1",
+               vehs_per_hour=flow_rate,
+               departLane="random", departSpeed=10)
+    net_params.inflows = inflow
 
     # modify the rendering to match what is requested
     sumo_params.render = render

--- a/flow/benchmarks/baselines/bottleneck1.py
+++ b/flow/benchmarks/baselines/bottleneck1.py
@@ -3,24 +3,13 @@
 Baseline is no AVs.
 """
 
-from flow.core.params import SumoParams, EnvParams, InitialConfig, NetParams, \
-    InFlows
-from flow.core.traffic_lights import TrafficLights
-from flow.core.vehicles import Vehicles
-from flow.controllers import ContinuousRouter
-from flow.envs.bottleneck_env import DesiredVelocityEnv
-from flow.core.experiment import SumoExperiment
-from flow.scenarios.bottleneck import BottleneckScenario
 import numpy as np
-
-# time horizon of a single rollout
-HORIZON = 1000
-
-SCALING = 1
-NUM_LANES = 4 * SCALING  # number of lanes in the widest highway
-DISABLE_TB = True
-DISABLE_RAMP_METER = True
-AV_FRAC = 0.25
+from flow.core.experiment import SumoExperiment
+from flow.core.params import InitialConfig
+from flow.core.vehicles import Vehicles
+from flow.core.traffic_lights import TrafficLights
+from flow.controllers import ContinuousRouter
+from flow.benchmarks.bottleneck1 import flow_params, SCALING
 
 
 def bottleneck1_baseline(num_runs, render=True):
@@ -39,6 +28,14 @@ def bottleneck1_baseline(num_runs, render=True):
         SumoExperiment
             class needed to run simulations
     """
+    exp_tag = flow_params["exp_tag"]
+    sumo_params = flow_params["sumo"]
+    env_params = flow_params["env"]
+    net_params = flow_params["net"]
+    initial_config = flow_params.get("initial", InitialConfig())
+    traffic_lights = flow_params.get("tls", TrafficLights())
+
+    # remove autonomous vehicles
     vehicles = Vehicles()
     vehicles.add(veh_id="human",
                  speed_mode=9,
@@ -46,77 +43,32 @@ def bottleneck1_baseline(num_runs, render=True):
                  lane_change_mode=1621,
                  num_vehicles=1 * SCALING)
 
-    controlled_segments = [("1", 1, False), ("2", 2, True), ("3", 2, True),
-                           ("4", 2, True), ("5", 1, False)]
-    num_observed_segments = [("1", 1), ("2", 3), ("3", 3),
-                             ("4", 3), ("5", 1)]
-    additional_env_params = {
-        "target_velocity": 40,
-        "disable_tb": True,
-        "disable_ramp_metering": True,
-        "controlled_segments": controlled_segments,
-        "symmetric": False,
-        "observed_segments": num_observed_segments,
-        "reset_inflow": False,
-        "lane_change_duration": 5,
-        "max_accel": 3,
-        "max_decel": 3,
-        "inflow_range": [1000, 2000]
-    }
+    # modify the rendering to match what is requested
+    sumo_params.render = render
 
-    # flow rate
-    flow_rate = 1900 * SCALING
+    # import the scenario class
+    module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
+    scenario_class = getattr(module, flow_params["scenario"])
 
-    # percentage of flow coming out of each lane
-    inflow = InFlows()
-    inflow.add(veh_type="human", edge="1",
-               vehs_per_hour=flow_rate,
-               departLane="random", departSpeed=10)
-
-    traffic_lights = TrafficLights()
-    if not DISABLE_TB:
-        traffic_lights.add(node_id="2")
-    if not DISABLE_RAMP_METER:
-        traffic_lights.add(node_id="3")
-
-    additional_net_params = {"scaling": SCALING}
-    net_params = NetParams(inflows=inflow,
-                           no_internal_links=False,
-                           additional_params=additional_net_params)
-
-    sumo_params = SumoParams(
-        sim_step=0.5,
-        render=render,
-        print_warnings=False,
-        restart_instance=False,
+    # create the scenario object
+    scenario = scenario_class(
+        name=exp_tag,
+        vehicles=vehicles,
+        net_params=net_params,
+        initial_config=initial_config,
+        traffic_lights=traffic_lights
     )
 
-    env_params = EnvParams(
-        evaluate=True,  # Set to True to evaluate traffic metrics
-        warmup_steps=40,
-        sims_per_step=1,
-        horizon=HORIZON,
-        additional_params=additional_env_params,
-    )
+    # import the environment class
+    module = __import__("flow.envs", fromlist=[flow_params["env_name"]])
+    env_class = getattr(module, flow_params["env_name"])
 
-    initial_config = InitialConfig(
-        spacing="uniform",
-        min_gap=5,
-        lanes_distribution=float("inf"),
-        edges_distribution=["2", "3", "4", "5"],
-    )
-
-    scenario = BottleneckScenario(name="bay_bridge_toll",
-                                  vehicles=vehicles,
-                                  net_params=net_params,
-                                  initial_config=initial_config,
-                                  traffic_lights=traffic_lights)
-
-    env = DesiredVelocityEnv(env_params, sumo_params, scenario)
+    # create the environment object
+    env = env_class(env_params, sumo_params, scenario)
 
     exp = SumoExperiment(env, scenario)
 
-    results = exp.run(num_runs, HORIZON)
+    results = exp.run(num_runs, env_params.horizon)
 
     return np.mean(results["returns"]), np.std(results["returns"])
 

--- a/flow/benchmarks/baselines/bottleneck1.py
+++ b/flow/benchmarks/baselines/bottleneck1.py
@@ -54,6 +54,9 @@ def bottleneck1_baseline(num_runs, render=True):
     # modify the rendering to match what is requested
     sumo_params.render = render
 
+    # set the evaluation flag to True
+    env_params.evaluate = True
+
     # import the scenario class
     module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
     scenario_class = getattr(module, flow_params["scenario"])

--- a/flow/benchmarks/baselines/bottleneck1.py
+++ b/flow/benchmarks/baselines/bottleneck1.py
@@ -5,7 +5,8 @@ Baseline is no AVs.
 
 import numpy as np
 from flow.core.experiment import SumoExperiment
-from flow.core.params import InitialConfig, InFlows
+from flow.core.params import InitialConfig
+from flow.core.params import InFlows
 from flow.core.vehicles import Vehicles
 from flow.core.traffic_lights import TrafficLights
 from flow.controllers import ContinuousRouter
@@ -28,16 +29,16 @@ def bottleneck1_baseline(num_runs, render=True):
         SumoExperiment
             class needed to run simulations
     """
-    exp_tag = flow_params["exp_tag"]
-    sumo_params = flow_params["sumo"]
-    env_params = flow_params["env"]
-    net_params = flow_params["net"]
-    initial_config = flow_params.get("initial", InitialConfig())
-    traffic_lights = flow_params.get("tls", TrafficLights())
+    exp_tag = flow_params['exp_tag']
+    sumo_params = flow_params['sumo']
+    env_params = flow_params['env']
+    net_params = flow_params['net']
+    initial_config = flow_params.get('initial', InitialConfig())
+    traffic_lights = flow_params.get('tls', TrafficLights())
 
     # remove autonomous vehicles
     vehicles = Vehicles()
-    vehicles.add(veh_id="human",
+    vehicles.add(veh_id='human',
                  speed_mode=9,
                  routing_controller=(ContinuousRouter, {}),
                  lane_change_mode=1621,
@@ -46,9 +47,9 @@ def bottleneck1_baseline(num_runs, render=True):
     # modify the inflows to only include human vehicles
     flow_rate = 1900 * SCALING
     inflow = InFlows()
-    inflow.add(veh_type="human", edge="1",
+    inflow.add(veh_type='human', edge='1',
                vehs_per_hour=flow_rate,
-               departLane="random", departSpeed=10)
+               departLane='random', departSpeed=10)
     net_params.inflows = inflow
 
     # modify the rendering to match what is requested
@@ -58,8 +59,8 @@ def bottleneck1_baseline(num_runs, render=True):
     env_params.evaluate = True
 
     # import the scenario class
-    module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
-    scenario_class = getattr(module, flow_params["scenario"])
+    module = __import__('flow.scenarios', fromlist=[flow_params['scenario']])
+    scenario_class = getattr(module, flow_params['scenario'])
 
     # create the scenario object
     scenario = scenario_class(
@@ -71,8 +72,8 @@ def bottleneck1_baseline(num_runs, render=True):
     )
 
     # import the environment class
-    module = __import__("flow.envs", fromlist=[flow_params["env_name"]])
-    env_class = getattr(module, flow_params["env_name"])
+    module = __import__('flow.envs', fromlist=[flow_params['env_name']])
+    env_class = getattr(module, flow_params['env_name'])
 
     # create the environment object
     env = env_class(env_params, sumo_params, scenario)
@@ -81,10 +82,10 @@ def bottleneck1_baseline(num_runs, render=True):
 
     results = exp.run(num_runs, env_params.horizon)
 
-    return np.mean(results["returns"]), np.std(results["returns"])
+    return np.mean(results['returns']), np.std(results['returns'])
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     runs = 2  # number of simulations to average over
     mean, std = bottleneck1_baseline(num_runs=runs, render=False)
 

--- a/flow/benchmarks/baselines/bottleneck2.py
+++ b/flow/benchmarks/baselines/bottleneck2.py
@@ -37,7 +37,7 @@ def bottleneck2_baseline(num_runs, render=True):
     initial_config = flow_params.get('initial', InitialConfig())
     traffic_lights = flow_params.get('tls', TrafficLights())
 
-    # remove autonomous vehicles
+    # we want no autonomous vehicles in the simulation
     vehicles = Vehicles()
     vehicles.add(veh_id='human',
                  speed_mode=9,
@@ -45,7 +45,7 @@ def bottleneck2_baseline(num_runs, render=True):
                  lane_change_mode=0,
                  num_vehicles=1 * SCALING)
 
-    # modify the inflows to only include human vehicles
+    # only include human vehicles in inflows
     flow_rate = 1900 * SCALING
     inflow = InFlows()
     inflow.add(veh_type='human', edge='1',

--- a/flow/benchmarks/baselines/bottleneck2.py
+++ b/flow/benchmarks/baselines/bottleneck2.py
@@ -5,7 +5,8 @@ Baseline is no AVs.
 
 import numpy as np
 from flow.core.experiment import SumoExperiment
-from flow.core.params import InitialConfig, InFlows
+from flow.core.params import InitialConfig
+from flow.core.params import InFlows
 from flow.core.vehicles import Vehicles
 from flow.core.traffic_lights import TrafficLights
 from flow.controllers import ContinuousRouter
@@ -28,16 +29,16 @@ def bottleneck2_baseline(num_runs, render=True):
         SumoExperiment
             class needed to run simulations
     """
-    exp_tag = flow_params["exp_tag"]
-    sumo_params = flow_params["sumo"]
-    env_params = flow_params["env"]
-    net_params = flow_params["net"]
-    initial_config = flow_params.get("initial", InitialConfig())
-    traffic_lights = flow_params.get("tls", TrafficLights())
+    exp_tag = flow_params['exp_tag']
+    sumo_params = flow_params['sumo']
+    env_params = flow_params['env']
+    net_params = flow_params['net']
+    initial_config = flow_params.get('initial', InitialConfig())
+    traffic_lights = flow_params.get('tls', TrafficLights())
 
     # remove autonomous vehicles
     vehicles = Vehicles()
-    vehicles.add(veh_id="human",
+    vehicles.add(veh_id='human',
                  speed_mode=9,
                  routing_controller=(ContinuousRouter, {}),
                  lane_change_mode=0,
@@ -46,9 +47,9 @@ def bottleneck2_baseline(num_runs, render=True):
     # modify the inflows to only include human vehicles
     flow_rate = 1900 * SCALING
     inflow = InFlows()
-    inflow.add(veh_type="human", edge="1",
+    inflow.add(veh_type='human', edge='1',
                vehs_per_hour=flow_rate,
-               departLane="random", departSpeed=10)
+               departLane='random', departSpeed=10)
     net_params.inflows = inflow
 
     # modify the rendering to match what is requested
@@ -58,8 +59,8 @@ def bottleneck2_baseline(num_runs, render=True):
     env_params.evaluate = True
 
     # import the scenario class
-    module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
-    scenario_class = getattr(module, flow_params["scenario"])
+    module = __import__('flow.scenarios', fromlist=[flow_params['scenario']])
+    scenario_class = getattr(module, flow_params['scenario'])
 
     # create the scenario object
     scenario = scenario_class(
@@ -71,8 +72,8 @@ def bottleneck2_baseline(num_runs, render=True):
     )
 
     # import the environment class
-    module = __import__("flow.envs", fromlist=[flow_params["env_name"]])
-    env_class = getattr(module, flow_params["env_name"])
+    module = __import__('flow.envs', fromlist=[flow_params['env_name']])
+    env_class = getattr(module, flow_params['env_name'])
 
     # create the environment object
     env = env_class(env_params, sumo_params, scenario)
@@ -81,10 +82,10 @@ def bottleneck2_baseline(num_runs, render=True):
 
     results = exp.run(num_runs, env_params.horizon)
 
-    return np.mean(results["returns"]), np.std(results["returns"])
+    return np.mean(results['returns']), np.std(results['returns'])
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     runs = 2  # number of simulations to average over
     mean, std = bottleneck2_baseline(num_runs=runs, render=False)
 

--- a/flow/benchmarks/baselines/bottleneck2.py
+++ b/flow/benchmarks/baselines/bottleneck2.py
@@ -9,7 +9,7 @@ from flow.core.params import InitialConfig, InFlows
 from flow.core.vehicles import Vehicles
 from flow.core.traffic_lights import TrafficLights
 from flow.controllers import ContinuousRouter
-from flow.benchmarks.bottleneck1 import flow_params, SCALING
+from flow.benchmarks.bottleneck2 import flow_params, SCALING
 
 
 def bottleneck2_baseline(num_runs, render=True):

--- a/flow/benchmarks/baselines/bottleneck2.py
+++ b/flow/benchmarks/baselines/bottleneck2.py
@@ -3,24 +3,13 @@
 Baseline is no AVs.
 """
 
-from flow.core.params import SumoParams, EnvParams, InitialConfig, NetParams, \
-    InFlows
-from flow.core.traffic_lights import TrafficLights
-from flow.core.vehicles import Vehicles
-from flow.controllers import ContinuousRouter
-from flow.envs.bottleneck_env import DesiredVelocityEnv
-from flow.core.experiment import SumoExperiment
-from flow.scenarios.bottleneck import BottleneckScenario
 import numpy as np
-
-# time horizon of a single rollout
-HORIZON = 1000
-
-SCALING = 2
-NUM_LANES = 4 * SCALING  # number of lanes in the widest highway
-DISABLE_TB = True
-DISABLE_RAMP_METER = True
-AV_FRAC = .10
+from flow.core.experiment import SumoExperiment
+from flow.core.params import InitialConfig
+from flow.core.vehicles import Vehicles
+from flow.core.traffic_lights import TrafficLights
+from flow.controllers import ContinuousRouter
+from flow.benchmarks.bottleneck1 import flow_params, SCALING
 
 
 def bottleneck2_baseline(num_runs, render=True):
@@ -39,6 +28,14 @@ def bottleneck2_baseline(num_runs, render=True):
         SumoExperiment
             class needed to run simulations
     """
+    exp_tag = flow_params["exp_tag"]
+    sumo_params = flow_params["sumo"]
+    env_params = flow_params["env"]
+    net_params = flow_params["net"]
+    initial_config = flow_params.get("initial", InitialConfig())
+    traffic_lights = flow_params.get("tls", TrafficLights())
+
+    # remove autonomous vehicles
     vehicles = Vehicles()
     vehicles.add(veh_id="human",
                  speed_mode=9,
@@ -46,77 +43,32 @@ def bottleneck2_baseline(num_runs, render=True):
                  lane_change_mode=0,
                  num_vehicles=1 * SCALING)
 
-    controlled_segments = [("1", 1, False), ("2", 2, True), ("3", 2, True),
-                           ("4", 2, True), ("5", 1, False)]
-    num_observed_segments = [("1", 1), ("2", 3), ("3", 3),
-                             ("4", 3), ("5", 1)]
-    additional_env_params = {
-        "target_velocity": 40,
-        "disable_tb": True,
-        "disable_ramp_metering": True,
-        "controlled_segments": controlled_segments,
-        "symmetric": False,
-        "observed_segments": num_observed_segments,
-        "reset_inflow": False,
-        "lane_change_duration": 5,
-        "max_accel": 3,
-        "max_decel": 3,
-        "inflow_range": [1000, 2000]
-    }
+    # modify the rendering to match what is requested
+    sumo_params.render = render
 
-    # flow rate
-    flow_rate = 1900 * SCALING
+    # import the scenario class
+    module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
+    scenario_class = getattr(module, flow_params["scenario"])
 
-    # percentage of flow coming out of each lane
-    inflow = InFlows()
-    inflow.add(veh_type="human", edge="1",
-               vehs_per_hour=flow_rate,
-               departLane="random", departSpeed=10)
-
-    traffic_lights = TrafficLights()
-    if not DISABLE_TB:
-        traffic_lights.add(node_id="2")
-    if not DISABLE_RAMP_METER:
-        traffic_lights.add(node_id="3")
-
-    additional_net_params = {"scaling": SCALING}
-    net_params = NetParams(inflows=inflow,
-                           no_internal_links=False,
-                           additional_params=additional_net_params)
-
-    sumo_params = SumoParams(
-        sim_step=0.5,
-        render=render,
-        print_warnings=False,
-        restart_instance=False,
+    # create the scenario object
+    scenario = scenario_class(
+        name=exp_tag,
+        vehicles=vehicles,
+        net_params=net_params,
+        initial_config=initial_config,
+        traffic_lights=traffic_lights
     )
 
-    env_params = EnvParams(
-        evaluate=True,  # Set to True to evaluate traffic metrics
-        warmup_steps=40,
-        sims_per_step=1,
-        horizon=HORIZON,
-        additional_params=additional_env_params,
-    )
+    # import the environment class
+    module = __import__("flow.envs", fromlist=[flow_params["env_name"]])
+    env_class = getattr(module, flow_params["env_name"])
 
-    initial_config = InitialConfig(
-        spacing="uniform",
-        min_gap=5,
-        lanes_distribution=float("inf"),
-        edges_distribution=["2", "3", "4", "5"],
-    )
-
-    scenario = BottleneckScenario(name="bay_bridge_toll",
-                                  vehicles=vehicles,
-                                  net_params=net_params,
-                                  initial_config=initial_config,
-                                  traffic_lights=traffic_lights)
-
-    env = DesiredVelocityEnv(env_params, sumo_params, scenario)
+    # create the environment object
+    env = env_class(env_params, sumo_params, scenario)
 
     exp = SumoExperiment(env, scenario)
 
-    results = exp.run(num_runs, HORIZON)
+    results = exp.run(num_runs, env_params.horizon)
 
     return np.mean(results["returns"]), np.std(results["returns"])
 

--- a/flow/benchmarks/baselines/bottleneck2.py
+++ b/flow/benchmarks/baselines/bottleneck2.py
@@ -5,7 +5,7 @@ Baseline is no AVs.
 
 import numpy as np
 from flow.core.experiment import SumoExperiment
-from flow.core.params import InitialConfig
+from flow.core.params import InitialConfig, InFlows
 from flow.core.vehicles import Vehicles
 from flow.core.traffic_lights import TrafficLights
 from flow.controllers import ContinuousRouter
@@ -42,6 +42,14 @@ def bottleneck2_baseline(num_runs, render=True):
                  routing_controller=(ContinuousRouter, {}),
                  lane_change_mode=0,
                  num_vehicles=1 * SCALING)
+
+    # modify the inflows to only include human vehicles
+    flow_rate = 1900 * SCALING
+    inflow = InFlows()
+    inflow.add(veh_type="human", edge="1",
+               vehs_per_hour=flow_rate,
+               departLane="random", departSpeed=10)
+    net_params.inflows = inflow
 
     # modify the rendering to match what is requested
     sumo_params.render = render

--- a/flow/benchmarks/baselines/bottleneck2.py
+++ b/flow/benchmarks/baselines/bottleneck2.py
@@ -54,6 +54,9 @@ def bottleneck2_baseline(num_runs, render=True):
     # modify the rendering to match what is requested
     sumo_params.render = render
 
+    # set the evaluation flag to True
+    env_params.evaluate = True
+
     # import the scenario class
     module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
     scenario_class = getattr(module, flow_params["scenario"])

--- a/flow/benchmarks/baselines/figureeight012.py
+++ b/flow/benchmarks/baselines/figureeight012.py
@@ -38,6 +38,9 @@ def figure_eight_baseline(num_runs, render=True):
     # modify the rendering to match what is requested
     sumo_params.render = render
 
+    # set the evaluation flag to True
+    env_params.evaluate = True
+
     # we want no autonomous vehicles in the simulation
     vehicles = Vehicles()
     vehicles.add(veh_id="human",

--- a/flow/benchmarks/baselines/figureeight012.py
+++ b/flow/benchmarks/baselines/figureeight012.py
@@ -12,7 +12,7 @@ from flow.controllers import IDMController, ContinuousRouter
 from flow.benchmarks.figureeight0 import flow_params
 
 
-def figure_eight_baseline(num_runs, render=True):
+def figure_eight_baseline(num_runs, flow_params, render=True):
     """Run script for all figure eight baselines.
 
     Parameters
@@ -20,6 +20,9 @@ def figure_eight_baseline(num_runs, render=True):
         num_runs : int
             number of rollouts the performance of the environment is evaluated
             over
+        flow_params : dict
+            the flow meta-parameters describing the structure of a benchmark.
+            Must be one of the figure eight flow_params
         render : bool, optional
             specifies whether to use sumo's gui during execution
 
@@ -79,7 +82,7 @@ def figure_eight_baseline(num_runs, render=True):
 
 if __name__ == "__main__":
     runs = 2  # number of simulations to average over
-    res = figure_eight_baseline(num_runs=runs)
+    res = figure_eight_baseline(num_runs=runs, flow_params=flow_params)
 
     print('---------')
     print('The average speed across {} runs is {}'.format(runs, res))

--- a/flow/benchmarks/baselines/figureeight012.py
+++ b/flow/benchmarks/baselines/figureeight012.py
@@ -31,12 +31,12 @@ def figure_eight_baseline(num_runs, flow_params, render=True):
         SumoExperiment
             class needed to run simulations
     """
-    exp_tag = flow_params["exp_tag"]
-    sumo_params = flow_params["sumo"]
-    env_params = flow_params["env"]
-    net_params = flow_params["net"]
-    initial_config = flow_params.get("initial", InitialConfig())
-    traffic_lights = flow_params.get("tls", TrafficLights())
+    exp_tag = flow_params['exp_tag']
+    sumo_params = flow_params['sumo']
+    env_params = flow_params['env']
+    net_params = flow_params['net']
+    initial_config = flow_params.get('initial', InitialConfig())
+    traffic_lights = flow_params.get('tls', TrafficLights())
 
     # modify the rendering to match what is requested
     sumo_params.render = render
@@ -46,15 +46,15 @@ def figure_eight_baseline(num_runs, flow_params, render=True):
 
     # we want no autonomous vehicles in the simulation
     vehicles = Vehicles()
-    vehicles.add(veh_id="human",
-                 acceleration_controller=(IDMController, {"noise": 0.2}),
+    vehicles.add(veh_id='human',
+                 acceleration_controller=(IDMController, {'noise': 0.2}),
                  routing_controller=(ContinuousRouter, {}),
-                 speed_mode="no_collide",
+                 speed_mode='no_collide',
                  num_vehicles=14)
 
     # import the scenario class
-    module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
-    scenario_class = getattr(module, flow_params["scenario"])
+    module = __import__('flow.scenarios', fromlist=[flow_params['scenario']])
+    scenario_class = getattr(module, flow_params['scenario'])
 
     # create the scenario object
     scenario = scenario_class(
@@ -66,8 +66,8 @@ def figure_eight_baseline(num_runs, flow_params, render=True):
     )
 
     # import the environment class
-    module = __import__("flow.envs", fromlist=[flow_params["env_name"]])
-    env_class = getattr(module, flow_params["env_name"])
+    module = __import__('flow.envs', fromlist=[flow_params['env_name']])
+    env_class = getattr(module, flow_params['env_name'])
 
     # create the environment object
     env = env_class(env_params, sumo_params, scenario)
@@ -75,12 +75,12 @@ def figure_eight_baseline(num_runs, flow_params, render=True):
     exp = SumoExperiment(env, scenario)
 
     results = exp.run(num_runs, env_params.horizon)
-    avg_speed = np.mean(results["mean_returns"])
+    avg_speed = np.mean(results['mean_returns'])
 
     return avg_speed
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     runs = 2  # number of simulations to average over
     res = figure_eight_baseline(num_runs=runs, flow_params=flow_params)
 

--- a/flow/benchmarks/baselines/grid0.py
+++ b/flow/benchmarks/baselines/grid0.py
@@ -3,34 +3,11 @@
 Baseline is an actuated traffic light provided by SUMO.
 """
 
-from flow.core.params import SumoParams, EnvParams, InitialConfig, NetParams, \
-    InFlows, SumoCarFollowingParams
-from flow.core.vehicles import Vehicles
-from flow.core.traffic_lights import TrafficLights
-from flow.controllers import SumoCarFollowingController, GridRouter
-from flow.envs.green_wave_env import PO_TrafficLightGridEnv
-from flow.core.experiment import SumoExperiment
-from flow.scenarios.grid import SimpleGridScenario
 import numpy as np
-
-# time horizon of a single rollout
-HORIZON = 400
-# inflow rate of vehicles at every edge
-EDGE_INFLOW = 300
-# enter speed for departing vehicles
-V_ENTER = 30
-# number of row of bidirectional lanes
-N_ROWS = 3
-# number of columns of bidirectional lanes
-N_COLUMNS = 3
-# length of inner edges in the grid network
-INNER_LENGTH = 300
-# length of final edge in route
-LONG_LENGTH = 100
-# length of edges that vehicles start on
-SHORT_LENGTH = 300
-# number of vehicles originating in the left, right, top, and bottom edges
-N_LEFT, N_RIGHT, N_TOP, N_BOTTOM = 1, 1, 1, 1
+from flow.core.experiment import SumoExperiment
+from flow.core.params import InitialConfig
+from flow.core.traffic_lights import TrafficLights
+from flow.benchmarks.grid0 import flow_params, N_ROWS, N_COLUMNS
 
 
 def grid0_baseline(num_runs, render=True):
@@ -49,33 +26,12 @@ def grid0_baseline(num_runs, render=True):
         SumoExperiment
             class needed to run simulations
     """
-    # we place a sufficient number of vehicles to ensure they confirm with the
-    # total number specified above. We also use a "right_of_way" speed mode to
-    # support traffic light compliance
-    vehicles = Vehicles()
-    vehicles.add(veh_id="human",
-                 acceleration_controller=(SumoCarFollowingController, {}),
-                 sumo_car_following_params=SumoCarFollowingParams(
-                     min_gap=2.5,
-                     max_speed=V_ENTER,
-                 ),
-                 routing_controller=(GridRouter, {}),
-                 num_vehicles=(N_LEFT+N_RIGHT)*N_COLUMNS +
-                              (N_BOTTOM+N_TOP)*N_ROWS,
-                 speed_mode="right_of_way")
-
-    # inflows of vehicles are place on all outer edges (listed here)
-    outer_edges = []
-    outer_edges += ["left{}_{}".format(N_ROWS, i) for i in range(N_COLUMNS)]
-    outer_edges += ["right0_{}".format(i) for i in range(N_ROWS)]
-    outer_edges += ["bot{}_0".format(i) for i in range(N_ROWS)]
-    outer_edges += ["top{}_{}".format(i, N_COLUMNS) for i in range(N_ROWS)]
-
-    # equal inflows for each edge (as dictate by the EDGE_INFLOW constant)
-    inflow = InFlows()
-    for edge in outer_edges:
-        inflow.add(veh_type="human", edge=edge, vehs_per_hour=EDGE_INFLOW,
-                   departLane="free", departSpeed="max")
+    exp_tag = flow_params["exp_tag"]
+    sumo_params = flow_params["sumo"]
+    vehicles = flow_params["veh"]
+    env_params = flow_params["env"]
+    net_params = flow_params["net"]
+    initial_config = flow_params.get("initial", InitialConfig())
 
     # define the traffic light logic
     tl_logic = TrafficLights(baseline=False)
@@ -89,62 +45,36 @@ def grid0_baseline(num_runs, render=True):
               {"duration": "2", "minDur": "2", "maxDur": "2",
                "state": "rrryyyrrryyy"}]
 
-    for i in range(N_ROWS*N_COLUMNS):
+    for i in range(N_ROWS * N_COLUMNS):
         tl_logic.add("center"+str(i), tls_type="actuated", phases=phases,
                      programID=1)
 
-    net_params = NetParams(
-            inflows=inflow,
-            no_internal_links=False,
-            additional_params={
-                "speed_limit": V_ENTER + 5,
-                "grid_array": {
-                    "short_length": SHORT_LENGTH,
-                    "inner_length": INNER_LENGTH,
-                    "long_length": LONG_LENGTH,
-                    "row_num": N_ROWS,
-                    "col_num": N_COLUMNS,
-                    "cars_left": N_LEFT,
-                    "cars_right": N_RIGHT,
-                    "cars_top": N_TOP,
-                    "cars_bot": N_BOTTOM,
-                },
-                "horizontal_lanes": 1,
-                "vertical_lanes": 1,
-            },
-        )
+    # modify the rendering to match what is requested
+    sumo_params.render = render
 
-    sumo_params = SumoParams(
-            restart_instance=False,
-            sim_step=1,
-            render=render,
-        )
+    # import the scenario class
+    module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
+    scenario_class = getattr(module, flow_params["scenario"])
 
-    env_params = EnvParams(
-            evaluate=True,  # Set to True to evaluate traffic metrics
-            horizon=HORIZON,
-            additional_params={
-                "target_velocity": 50,
-                "switch_time": 2,
-                "num_observed": 2,
-                "discrete": False,
-                "tl_type": "actuated"
-            },
-        )
+    # create the scenario object
+    scenario = scenario_class(
+        name=exp_tag,
+        vehicles=vehicles,
+        net_params=net_params,
+        initial_config=initial_config,
+        traffic_lights=tl_logic
+    )
 
-    initial_config = InitialConfig(shuffle=True)
+    # import the environment class
+    module = __import__("flow.envs", fromlist=[flow_params["env_name"]])
+    env_class = getattr(module, flow_params["env_name"])
 
-    scenario = SimpleGridScenario(name="grid",
-                                  vehicles=vehicles,
-                                  net_params=net_params,
-                                  initial_config=initial_config,
-                                  traffic_lights=tl_logic)
-
-    env = PO_TrafficLightGridEnv(env_params, sumo_params, scenario)
+    # create the environment object
+    env = env_class(env_params, sumo_params, scenario)
 
     exp = SumoExperiment(env, scenario)
 
-    results = exp.run(num_runs, HORIZON)
+    results = exp.run(num_runs, env_params.horizon)
     total_delay = np.mean(results["returns"])
 
     return total_delay

--- a/flow/benchmarks/baselines/grid0.py
+++ b/flow/benchmarks/baselines/grid0.py
@@ -52,6 +52,9 @@ def grid0_baseline(num_runs, render=True):
     # modify the rendering to match what is requested
     sumo_params.render = render
 
+    # set the evaluation flag to True
+    env_params.evaluate = True
+
     # import the scenario class
     module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
     scenario_class = getattr(module, flow_params["scenario"])

--- a/flow/benchmarks/baselines/grid0.py
+++ b/flow/benchmarks/baselines/grid0.py
@@ -26,27 +26,27 @@ def grid0_baseline(num_runs, render=True):
         SumoExperiment
             class needed to run simulations
     """
-    exp_tag = flow_params["exp_tag"]
-    sumo_params = flow_params["sumo"]
-    vehicles = flow_params["veh"]
-    env_params = flow_params["env"]
-    net_params = flow_params["net"]
-    initial_config = flow_params.get("initial", InitialConfig())
+    exp_tag = flow_params['exp_tag']
+    sumo_params = flow_params['sumo']
+    vehicles = flow_params['veh']
+    env_params = flow_params['env']
+    net_params = flow_params['net']
+    initial_config = flow_params.get('initial', InitialConfig())
 
     # define the traffic light logic
     tl_logic = TrafficLights(baseline=False)
 
-    phases = [{"duration": "31", "minDur": "5", "maxDur": "45",
-               "state": "GGGrrrGGGrrr"},
-              {"duration": "2", "minDur": "2", "maxDur": "2",
-               "state": "yyyrrryyyrrr"},
-              {"duration": "31", "minDur": "5", "maxDur": "45",
-               "state": "rrrGGGrrrGGG"},
-              {"duration": "2", "minDur": "2", "maxDur": "2",
-               "state": "rrryyyrrryyy"}]
+    phases = [{'duration': '31', 'minDur': '5', 'maxDur': '45',
+               'state': 'GGGrrrGGGrrr'},
+              {'duration': '2', 'minDur': '2', 'maxDur': '2',
+               'state': 'yyyrrryyyrrr'},
+              {'duration': '31', 'minDur': '5', 'maxDur': '45',
+               'state': 'rrrGGGrrrGGG'},
+              {'duration': '2', 'minDur': '2', 'maxDur': '2',
+               'state': 'rrryyyrrryyy'}]
 
     for i in range(N_ROWS * N_COLUMNS):
-        tl_logic.add("center"+str(i), tls_type="actuated", phases=phases,
+        tl_logic.add('center'+str(i), tls_type='actuated', phases=phases,
                      programID=1)
 
     # modify the rendering to match what is requested
@@ -56,8 +56,8 @@ def grid0_baseline(num_runs, render=True):
     env_params.evaluate = True
 
     # import the scenario class
-    module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
-    scenario_class = getattr(module, flow_params["scenario"])
+    module = __import__('flow.scenarios', fromlist=[flow_params['scenario']])
+    scenario_class = getattr(module, flow_params['scenario'])
 
     # create the scenario object
     scenario = scenario_class(
@@ -69,8 +69,8 @@ def grid0_baseline(num_runs, render=True):
     )
 
     # import the environment class
-    module = __import__("flow.envs", fromlist=[flow_params["env_name"]])
-    env_class = getattr(module, flow_params["env_name"])
+    module = __import__('flow.envs', fromlist=[flow_params['env_name']])
+    env_class = getattr(module, flow_params['env_name'])
 
     # create the environment object
     env = env_class(env_params, sumo_params, scenario)
@@ -78,12 +78,12 @@ def grid0_baseline(num_runs, render=True):
     exp = SumoExperiment(env, scenario)
 
     results = exp.run(num_runs, env_params.horizon)
-    total_delay = np.mean(results["returns"])
+    total_delay = np.mean(results['returns'])
 
     return total_delay
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     runs = 1  # number of simulations to average over
     res = grid0_baseline(num_runs=runs)
 

--- a/flow/benchmarks/baselines/grid1.py
+++ b/flow/benchmarks/baselines/grid1.py
@@ -50,6 +50,9 @@ def grid1_baseline(num_runs, render=True):
     # modify the rendering to match what is requested
     sumo_params.render = render
 
+    # set the evaluation flag to True
+    env_params.evaluate = True
+
     # import the scenario class
     module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
     scenario_class = getattr(module, flow_params["scenario"])

--- a/flow/benchmarks/baselines/grid1.py
+++ b/flow/benchmarks/baselines/grid1.py
@@ -3,34 +3,11 @@
 Baseline is an actuated traffic light provided by SUMO.
 """
 
-from flow.core.params import SumoParams, EnvParams, InitialConfig, NetParams, \
-    InFlows, SumoCarFollowingParams
-from flow.core.vehicles import Vehicles
-from flow.core.traffic_lights import TrafficLights
-from flow.controllers import SumoCarFollowingController, GridRouter
-from flow.envs.green_wave_env import PO_TrafficLightGridEnv
-from flow.core.experiment import SumoExperiment
-from flow.scenarios.grid import SimpleGridScenario
 import numpy as np
-
-# time horizon of a single rollout
-HORIZON = 400
-# inflow rate of vehicles at every edge
-EDGE_INFLOW = 300
-# enter speed for departing vehicles
-V_ENTER = 30
-# number of row of bidirectional lanes
-N_ROWS = 5
-# number of columns of bidirectional lanes
-N_COLUMNS = 5
-# length of inner edges in the grid network
-INNER_LENGTH = 300
-# length of final edge in route
-LONG_LENGTH = 100
-# length of edges that vehicles start on
-SHORT_LENGTH = 300
-# number of vehicles originating in the left, right, top, and bottom edges
-N_LEFT, N_RIGHT, N_TOP, N_BOTTOM = 1, 1, 1, 1
+from flow.core.experiment import SumoExperiment
+from flow.core.params import InitialConfig
+from flow.core.traffic_lights import TrafficLights
+from flow.benchmarks.grid1 import flow_params, N_ROWS, N_COLUMNS
 
 
 def grid1_baseline(num_runs, render=True):
@@ -49,33 +26,12 @@ def grid1_baseline(num_runs, render=True):
         SumoExperiment
             class needed to run simulations
     """
-    # we place a sufficient number of vehicles to ensure they confirm with the
-    # total number specified above. We also use a "right_of_way" speed mode to
-    # support traffic light compliance
-    vehicles = Vehicles()
-    vehicles.add(veh_id="human",
-                 acceleration_controller=(SumoCarFollowingController, {}),
-                 sumo_car_following_params=SumoCarFollowingParams(
-                     min_gap=2.5,
-                     max_speed=V_ENTER,
-                 ),
-                 routing_controller=(GridRouter, {}),
-                 num_vehicles=(N_LEFT+N_RIGHT)*N_COLUMNS +
-                              (N_BOTTOM+N_TOP)*N_ROWS,
-                 speed_mode="right_of_way")
-
-    # inflows of vehicles are place on all outer edges (listed here)
-    outer_edges = []
-    outer_edges += ["left{}_{}".format(N_ROWS, i) for i in range(N_COLUMNS)]
-    outer_edges += ["right0_{}".format(i) for i in range(N_ROWS)]
-    outer_edges += ["bot{}_0".format(i) for i in range(N_ROWS)]
-    outer_edges += ["top{}_{}".format(i, N_COLUMNS) for i in range(N_ROWS)]
-
-    # equal inflows for each edge (as dictate by the EDGE_INFLOW constant)
-    inflow = InFlows()
-    for edge in outer_edges:
-        inflow.add(veh_type="human", edge=edge, vehs_per_hour=EDGE_INFLOW,
-                   departLane="free", departSpeed="max")
+    exp_tag = flow_params["exp_tag"]
+    sumo_params = flow_params["sumo"]
+    vehicles = flow_params["veh"]
+    env_params = flow_params["env"]
+    net_params = flow_params["net"]
+    initial_config = flow_params.get("initial", InitialConfig())
 
     # define the traffic light logic
     tl_logic = TrafficLights(baseline=False)
@@ -91,58 +47,32 @@ def grid1_baseline(num_runs, render=True):
         tl_logic.add("center"+str(i), tls_type="actuated", phases=phases,
                      programID=1)
 
-    net_params = NetParams(
-            inflows=inflow,
-            no_internal_links=False,
-            additional_params={
-                "speed_limit": V_ENTER + 5,
-                "grid_array": {
-                    "short_length": SHORT_LENGTH,
-                    "inner_length": INNER_LENGTH,
-                    "long_length": LONG_LENGTH,
-                    "row_num": N_ROWS,
-                    "col_num": N_COLUMNS,
-                    "cars_left": N_LEFT,
-                    "cars_right": N_RIGHT,
-                    "cars_top": N_TOP,
-                    "cars_bot": N_BOTTOM,
-                },
-                "horizontal_lanes": 1,
-                "vertical_lanes": 1,
-            },
-        )
+    # modify the rendering to match what is requested
+    sumo_params.render = render
 
-    sumo_params = SumoParams(
-            restart_instance=False,
-            sim_step=1,
-            render=render,
-        )
+    # import the scenario class
+    module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
+    scenario_class = getattr(module, flow_params["scenario"])
 
-    env_params = EnvParams(
-            evaluate=True,  # Set to True to evaluate traffic metrics
-            horizon=HORIZON,
-            additional_params={
-                "target_velocity": 50,
-                "switch_time": 2,
-                "num_observed": 2,
-                "discrete": False,
-                "tl_type": "actuated"
-            },
-        )
+    # create the scenario object
+    scenario = scenario_class(
+        name=exp_tag,
+        vehicles=vehicles,
+        net_params=net_params,
+        initial_config=initial_config,
+        traffic_lights=tl_logic
+    )
 
-    initial_config = InitialConfig(shuffle=True)
+    # import the environment class
+    module = __import__("flow.envs", fromlist=[flow_params["env_name"]])
+    env_class = getattr(module, flow_params["env_name"])
 
-    scenario = SimpleGridScenario(name="grid",
-                                  vehicles=vehicles,
-                                  net_params=net_params,
-                                  initial_config=initial_config,
-                                  traffic_lights=tl_logic)
-
-    env = PO_TrafficLightGridEnv(env_params, sumo_params, scenario)
+    # create the environment object
+    env = env_class(env_params, sumo_params, scenario)
 
     exp = SumoExperiment(env, scenario)
 
-    results = exp.run(num_runs, HORIZON)
+    results = exp.run(num_runs, env_params.horizon)
     total_delay = np.mean(results["returns"])
 
     return total_delay

--- a/flow/benchmarks/baselines/grid1.py
+++ b/flow/benchmarks/baselines/grid1.py
@@ -35,16 +35,16 @@ def grid1_baseline(num_runs, render=True):
 
     # define the traffic light logic
     tl_logic = TrafficLights(baseline=False)
-    phases = [{"duration": "31", "minDur": "5", "maxDur": "45",
-               "state": "GGGrrrGGGrrr"},
-              {"duration": "2", "minDur": "2", "maxDur": "2",
-               "state": "yyyrrryyyrrr"},
-              {"duration": "31", "minDur": "5", "maxDur": "45",
-               "state": "rrrGGGrrrGGG"},
-              {"duration": "2", "minDur": "2", "maxDur": "2",
-               "state": "rrryyyrrryyy"}]
+    phases = [{'duration': '31', 'minDur': '5', 'maxDur': '45',
+               'state': 'GGGrrrGGGrrr'},
+              {'duration': '2', 'minDur': '2', 'maxDur': '2',
+               'state': 'yyyrrryyyrrr'},
+              {'duration': '31', 'minDur': '5', 'maxDur': '45',
+               'state': 'rrrGGGrrrGGG'},
+              {'duration': '2', 'minDur': '2', 'maxDur': '2',
+               'state': 'rrryyyrrryyy'}]
     for i in range(N_ROWS*N_COLUMNS):
-        tl_logic.add("center"+str(i), tls_type="actuated", phases=phases,
+        tl_logic.add('center'+str(i), tls_type='actuated', phases=phases,
                      programID=1)
 
     # modify the rendering to match what is requested
@@ -54,8 +54,8 @@ def grid1_baseline(num_runs, render=True):
     env_params.evaluate = True
 
     # import the scenario class
-    module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
-    scenario_class = getattr(module, flow_params["scenario"])
+    module = __import__('flow.scenarios', fromlist=[flow_params['scenario']])
+    scenario_class = getattr(module, flow_params['scenario'])
 
     # create the scenario object
     scenario = scenario_class(
@@ -67,8 +67,8 @@ def grid1_baseline(num_runs, render=True):
     )
 
     # import the environment class
-    module = __import__("flow.envs", fromlist=[flow_params["env_name"]])
-    env_class = getattr(module, flow_params["env_name"])
+    module = __import__('flow.envs', fromlist=[flow_params['env_name']])
+    env_class = getattr(module, flow_params['env_name'])
 
     # create the environment object
     env = env_class(env_params, sumo_params, scenario)
@@ -76,12 +76,12 @@ def grid1_baseline(num_runs, render=True):
     exp = SumoExperiment(env, scenario)
 
     results = exp.run(num_runs, env_params.horizon)
-    total_delay = np.mean(results["returns"])
+    total_delay = np.mean(results['returns'])
 
     return total_delay
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     runs = 1  # number of simulations to average over
     res = grid1_baseline(num_runs=runs, render=False)
 

--- a/flow/benchmarks/baselines/merge012.py
+++ b/flow/benchmarks/baselines/merge012.py
@@ -3,24 +3,11 @@
 Baseline is no AVs.
 """
 
-from flow.core.params import SumoParams, EnvParams, InitialConfig, NetParams, \
-    InFlows
-from flow.scenarios.merge import ADDITIONAL_NET_PARAMS
-from flow.core.vehicles import Vehicles
-from flow.core.experiment import SumoExperiment
-from flow.controllers import SumoCarFollowingController
-from flow.scenarios.merge import MergeScenario
-from flow.envs.merge import WaveAttenuationMergePOEnv
 import numpy as np
-
-# time horizon of a single rollout
-HORIZON = 750
-# inflow rate at the highway
-FLOW_RATE = 2000
-# percent of autonomous vehicles
-RL_PENETRATION = 0.1
-# num_rl term (see ADDITIONAL_ENV_PARAMs)
-NUM_RL = 5
+from flow.core.experiment import SumoExperiment
+from flow.core.params import InitialConfig
+from flow.core.traffic_lights import TrafficLights
+from flow.benchmarks.merge0 import flow_params
 
 
 def merge_baseline(num_runs, render=True):
@@ -39,66 +26,40 @@ def merge_baseline(num_runs, render=True):
         SumoExperiment
             class needed to run simulations
     """
-    # We consider a highway network with an upstream merging lane producing
-    # shockwaves
-    additional_net_params = ADDITIONAL_NET_PARAMS.copy()
-    additional_net_params["merge_lanes"] = 1
-    additional_net_params["highway_lanes"] = 1
-    additional_net_params["pre_merge_length"] = 500
+    exp_tag = flow_params["exp_tag"]
+    sumo_params = flow_params["sumo"]
+    vehicles = flow_params["veh"]
+    env_params = flow_params["env"]
+    net_params = flow_params["net"]
+    initial_config = flow_params.get("initial", InitialConfig())
+    traffic_lights = flow_params.get("tls", TrafficLights())
 
-    # RL vehicles constitute 5% of the total number of vehicles
-    vehicles = Vehicles()
-    vehicles.add(veh_id="human",
-                 acceleration_controller=(SumoCarFollowingController, {}),
-                 speed_mode=9,
-                 num_vehicles=5)
+    # modify the rendering to match what is requested
+    sumo_params.render = render
 
-    # Vehicles are introduced from both sides of merge, with RL vehicles
-    # entering from the highway portion as well
-    inflow = InFlows()
-    inflow.add(veh_type="human", edge="inflow_highway",
-               vehs_per_hour=FLOW_RATE,
-               departLane="free", departSpeed=10)
-    inflow.add(veh_type="human", edge="inflow_merge", vehs_per_hour=100,
-               departLane="free", departSpeed=7.5)
+    # import the scenario class
+    module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
+    scenario_class = getattr(module, flow_params["scenario"])
 
-    sumo_params = SumoParams(
-        restart_instance=True,
-        sim_step=0.5,  # time step decreased to prevent occasional crashes
-        render=render,
+    # create the scenario object
+    scenario = scenario_class(
+        name=exp_tag,
+        vehicles=vehicles,
+        net_params=net_params,
+        initial_config=initial_config,
+        traffic_lights=traffic_lights
     )
 
-    env_params = EnvParams(
-        horizon=HORIZON,
-        sims_per_step=5,  # value raised to ensure sec/step match experiment
-        warmup_steps=0,
-        evaluate=True,  # Set to True to evaluate traffic metric performance
-        additional_params={
-            "max_accel": 1.5,
-            "max_decel": 1.5,
-            "target_velocity": 20,
-            "num_rl": NUM_RL,
-        },
-    )
+    # import the environment class
+    module = __import__("flow.envs", fromlist=[flow_params["env_name"]])
+    env_class = getattr(module, flow_params["env_name"])
 
-    initial_config = InitialConfig()
-
-    net_params = NetParams(
-        inflows=inflow,
-        no_internal_links=False,
-        additional_params=additional_net_params,
-    )
-
-    scenario = MergeScenario(name="merge",
-                             vehicles=vehicles,
-                             net_params=net_params,
-                             initial_config=initial_config)
-
-    env = WaveAttenuationMergePOEnv(env_params, sumo_params, scenario)
+    # create the environment object
+    env = env_class(env_params, sumo_params, scenario)
 
     exp = SumoExperiment(env, scenario)
 
-    results = exp.run(num_runs, HORIZON)
+    results = exp.run(num_runs, env_params.horizon)
     avg_speed = np.mean(results["mean_returns"])
 
     return avg_speed

--- a/flow/benchmarks/baselines/merge012.py
+++ b/flow/benchmarks/baselines/merge012.py
@@ -29,13 +29,13 @@ def merge_baseline(num_runs, flow_params, render=True):
         SumoExperiment
             class needed to run simulations
     """
-    exp_tag = flow_params["exp_tag"]
-    sumo_params = flow_params["sumo"]
-    vehicles = flow_params["veh"]
-    env_params = flow_params["env"]
-    net_params = flow_params["net"]
-    initial_config = flow_params.get("initial", InitialConfig())
-    traffic_lights = flow_params.get("tls", TrafficLights())
+    exp_tag = flow_params['exp_tag']
+    sumo_params = flow_params['sumo']
+    vehicles = flow_params['veh']
+    env_params = flow_params['env']
+    net_params = flow_params['net']
+    initial_config = flow_params.get('initial', InitialConfig())
+    traffic_lights = flow_params.get('tls', TrafficLights())
 
     # modify the rendering to match what is requested
     sumo_params.render = render
@@ -44,8 +44,8 @@ def merge_baseline(num_runs, flow_params, render=True):
     env_params.evaluate = True
 
     # import the scenario class
-    module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
-    scenario_class = getattr(module, flow_params["scenario"])
+    module = __import__('flow.scenarios', fromlist=[flow_params['scenario']])
+    scenario_class = getattr(module, flow_params['scenario'])
 
     # create the scenario object
     scenario = scenario_class(
@@ -57,8 +57,8 @@ def merge_baseline(num_runs, flow_params, render=True):
     )
 
     # import the environment class
-    module = __import__("flow.envs", fromlist=[flow_params["env_name"]])
-    env_class = getattr(module, flow_params["env_name"])
+    module = __import__('flow.envs', fromlist=[flow_params['env_name']])
+    env_class = getattr(module, flow_params['env_name'])
 
     # create the environment object
     env = env_class(env_params, sumo_params, scenario)
@@ -66,12 +66,12 @@ def merge_baseline(num_runs, flow_params, render=True):
     exp = SumoExperiment(env, scenario)
 
     results = exp.run(num_runs, env_params.horizon)
-    avg_speed = np.mean(results["mean_returns"])
+    avg_speed = np.mean(results['mean_returns'])
 
     return avg_speed
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     runs = 2  # number of simulations to average over
     res = merge_baseline(num_runs=runs, flow_params=flow_params, render=False)
 

--- a/flow/benchmarks/baselines/merge012.py
+++ b/flow/benchmarks/baselines/merge012.py
@@ -37,6 +37,9 @@ def merge_baseline(num_runs, render=True):
     # modify the rendering to match what is requested
     sumo_params.render = render
 
+    # set the evaluation flag to True
+    env_params.evaluate = True
+
     # import the scenario class
     module = __import__("flow.scenarios", fromlist=[flow_params["scenario"]])
     scenario_class = getattr(module, flow_params["scenario"])

--- a/flow/benchmarks/baselines/merge012.py
+++ b/flow/benchmarks/baselines/merge012.py
@@ -10,7 +10,7 @@ from flow.core.traffic_lights import TrafficLights
 from flow.benchmarks.merge0 import flow_params
 
 
-def merge_baseline(num_runs, render=True):
+def merge_baseline(num_runs, flow_params, render=True):
     """Run script for all merge baselines.
 
     Parameters
@@ -18,6 +18,9 @@ def merge_baseline(num_runs, render=True):
         num_runs : int
             number of rollouts the performance of the environment is evaluated
             over
+        flow_params : dict
+            the flow meta-parameters describing the structure of a benchmark.
+            Must be one of the merge flow_params
         render: bool, optional
             specifies whether to use sumo's gui during execution
 
@@ -70,7 +73,7 @@ def merge_baseline(num_runs, render=True):
 
 if __name__ == "__main__":
     runs = 2  # number of simulations to average over
-    res = merge_baseline(num_runs=runs, render=False)
+    res = merge_baseline(num_runs=runs, flow_params=flow_params, render=False)
 
     print('---------')
     print('The average speed across {} runs is {}'.format(runs, res))

--- a/tests/slow_tests/test_benchmarks.py
+++ b/tests/slow_tests/test_benchmarks.py
@@ -1,6 +1,13 @@
 import unittest
 import os
 
+from flow.benchmarks.figureeight0 import flow_params as figureeight0
+from flow.benchmarks.figureeight1 import flow_params as figureeight1
+from flow.benchmarks.figureeight2 import flow_params as figureeight2
+from flow.benchmarks.merge0 import flow_params as merge0
+from flow.benchmarks.merge1 import flow_params as merge1
+from flow.benchmarks.merge2 import flow_params as merge2
+
 from flow.benchmarks.baselines.bottleneck0 import bottleneck0_baseline
 from flow.benchmarks.baselines.bottleneck1 import bottleneck1_baseline
 from flow.benchmarks.baselines.bottleneck2 import bottleneck2_baseline
@@ -50,8 +57,21 @@ class TestBaselines(unittest.TestCase):
         """
         Tests flow/benchmark/baselines/figureeight{0,1,2}.py
         """
-        # run the bottleneck to make sure it runs
-        figure_eight_baseline(num_runs=1, render=False)
+        # run the figure eight 0 to make sure it runs
+        figure_eight_baseline(num_runs=1, flow_params=figureeight0,
+                              render=False)
+
+        # TODO: check that the performance measure is within some range
+
+        # run the figure eight 1 to make sure it runs
+        figure_eight_baseline(num_runs=1, flow_params=figureeight1,
+                              render=False)
+
+        # TODO: check that the performance measure is within some range
+
+        # run the figure eight 2 to make sure it runs
+        figure_eight_baseline(num_runs=1, flow_params=figureeight2,
+                              render=False)
 
         # TODO: check that the performance measure is within some range
 
@@ -77,8 +97,18 @@ class TestBaselines(unittest.TestCase):
         """
         Tests flow/benchmark/baselines/merge{0,1,2}.py
         """
-        # run the bottleneck to make sure it runs
-        merge_baseline(num_runs=1, render=False)
+        # run the merge 0 to make sure it runs
+        merge_baseline(num_runs=1, flow_params=merge0, render=False)
+
+        # TODO: check that the performance measure is within some range
+
+        # run the merge 1 to make sure it runs
+        merge_baseline(num_runs=1, flow_params=merge1, render=False)
+
+        # TODO: check that the performance measure is within some range
+
+        # run the merge 2 to make sure it runs
+        merge_baseline(num_runs=1, flow_params=merge2, render=False)
 
         # TODO: check that the performance measure is within some range
 


### PR DESCRIPTION
By moving the `flow_params` dict to the simulations, we are added some coverage and certainty that these dictionaries are not broken (i.e. leading to failing simulations). This still needs to be complemented by tests regression tests, and ideally tests to ensure the baselines are receiving expected returns (although this is a bit difficult given the stochastic nature of some of the simulations).