### PR TITLE
added save movie option to visualizer rllib

### DIFF
--- a/docs/source/visualizing.rst
+++ b/docs/source/visualizing.rst
@@ -90,7 +90,7 @@ visualization instructions given above with the additional flag
 
 ::
 
-   python ./visualizer_rllab.py /result_dir/itr_XXX.pkl --sumo_web3d
+   python ./visualizer_rllab.py /result_dir/itr_XXX.pkl --sumo-web3d
 
 Then, either from the terminal logs pick out the printed port that has
 num-clients = 2 or you can run
@@ -113,6 +113,6 @@ Here you would pick out 61057 and then run
 
 ::
 
-   python sumo_web3d/sumo_web3d.py --sumo-port "port_num" -c "path to sumo.cfg"
+   python sumo_web3d/sumo_web3d.py --sumo-port "port-num" -c "path to sumo.cfg"
 
 where "port_num" is the port indicated above, 61057.

--- a/flow/renderer/pyglet_renderer.py
+++ b/flow/renderer/pyglet_renderer.py
@@ -60,7 +60,7 @@ class PygletRenderer():
         if self.mode not in [True, False, "rgb", "drgb", "gray", "dgray"]:
             raise ValueError("Mode %s is not supported!" % self.mode)
         self.save_render = save_render
-        self.path = path + '/' + time.strftime("%Y%m%d-%H%M%S")
+        self.path = path + '/' + time.strftime("%Y-%m-%d-%H%M%S")
         if self.save_render:
             if not os.path.exists(path):
                 os.mkdir(path)

--- a/flow/visualize/visualizer_rllib.py
+++ b/flow/visualize/visualizer_rllib.py
@@ -101,7 +101,7 @@ def visualizer_rllib(args):
 
     sumo_params.emission_path = './test_time_rollout/'
 
-    # pick your renderi
+    # pick your rendering mode
     if args.render_mode == 'sumo_web3d':
         sumo_params.num_clients = 2
         sumo_params.render = False
@@ -110,17 +110,13 @@ def visualizer_rllib(args):
         sumo_params.pxpm = 4
     elif args.render_mode == 'sumo_gui':
         sumo_params.render = True
+    elif args.render_mode == 'no_render':
+        sumo_params.render = False
 
     if args.save_render:
         sumo_params.render = 'drgb'
         sumo_params.pxpm = 4
         sumo_params.save_render = True
-
-    # modify sumo params for visualization ease
-    if args.no_render:
-        sumo_params.render = False
-    else:
-        sumo_params.render = True
 
     # Recreate the scenario from the pickled parameters
     exp_tag = flow_params['exp_tag']
@@ -285,10 +281,6 @@ def create_parser():
         help='Specifies whether to convert the emission file '
              'created by sumo into a csv file')
     parser.add_argument(
-        '--no_render',
-        action='store_true',
-        help='Specifies whether to visualize the results')
-    parser.add_argument(
         '--evaluate',
         action='store_true',
         help='Specifies whether to use the \'evaluate\' reward '
@@ -298,7 +290,7 @@ def create_parser():
         type=str,
         default='sumo_gui',
         help='Pick the render mode. Options include sumo_web3d, '
-             'rgbd and sumo_gui')
+             'rgbd, sumo_gui, and no_render')
     parser.add_argument(
         '--save_render',
         action='store_true',

--- a/flow/visualize/visualizer_rllib.py
+++ b/flow/visualize/visualizer_rllib.py
@@ -97,28 +97,30 @@ def visualizer_rllib(args):
               'python ./visualizer_rllib.py /tmp/ray/result_dir 1 --run PPO')
         sys.exit(1)
 
-    # modify sumo params for visualization ease
-    if args.no_render:
-        sumo_params.render = False
-    else:
-        sumo_params.render = True
-
     sumo_params.restart_instance = False
 
     sumo_params.emission_path = './test_time_rollout/'
 
-    # prepare for rendering
+    # pick your renderi
     if args.render_mode == 'sumo_web3d':
         sumo_params.num_clients = 2
         sumo_params.render = False
     elif args.render_mode == 'drgb':
         sumo_params.render = 'drgb'
+        sumo_params.pxpm = 4
     elif args.render_mode == 'sumo_gui':
         sumo_params.render = True
 
     if args.save_render:
         sumo_params.render = 'drgb'
+        sumo_params.pxpm = 4
         sumo_params.save_render = True
+
+    # modify sumo params for visualization ease
+    if args.no_render:
+        sumo_params.render = False
+    else:
+        sumo_params.render = True
 
     # Recreate the scenario from the pickled parameters
     exp_tag = flow_params['exp_tag']
@@ -247,7 +249,7 @@ def visualizer_rllib(args):
             os.mkdir(save_dir)
         os_cmd = "cd " + movie_dir + " && ffmpeg -i frame_%06d.png"
         os_cmd += " -pix_fmt yuv420p " + dirs[-1] + ".mp4"
-        os_cmd += "&& cp out.mp4 " + save_dir + "/"
+        os_cmd += "&& cp " + dirs[-1] + ".mp4 " + save_dir + "/"
         os.system(os_cmd)
 
 

--- a/flow/visualize/visualizer_rllib.py
+++ b/flow/visualize/visualizer_rllib.py
@@ -242,11 +242,12 @@ def visualizer_rllib(args):
         recent_dir = dirs[-1]
         # create the movie
         movie_dir = os.path.expanduser('~') + '/flow_rendering/' + recent_dir
+        import ipdb; ipdb.set_trace()
         save_dir = os.path.expanduser('~') + '/flow_movies'
         if not os.path.exists(save_dir):
             os.mkdir(save_dir)
         os_cmd = "cd " + movie_dir + " && ffmpeg -i frame_%06d.png"
-        os_cmd += " -pix_fmt yuv420p out.mp4"
+        os_cmd += " -pix_fmt yuv420p " + dirs[-1] + ".mp4"
         os_cmd += "&& cp out.mp4 " + save_dir + "/"
         os.system(os_cmd)
 

--- a/flow/visualize/visualizer_rllib.py
+++ b/flow/visualize/visualizer_rllib.py
@@ -242,7 +242,6 @@ def visualizer_rllib(args):
         recent_dir = dirs[-1]
         # create the movie
         movie_dir = os.path.expanduser('~') + '/flow_rendering/' + recent_dir
-        import ipdb; ipdb.set_trace()
         save_dir = os.path.expanduser('~') + '/flow_movies'
         if not os.path.exists(save_dir):
             os.mkdir(save_dir)
@@ -250,7 +249,6 @@ def visualizer_rllib(args):
         os_cmd += " -pix_fmt yuv420p " + dirs[-1] + ".mp4"
         os_cmd += "&& cp out.mp4 " + save_dir + "/"
         os.system(os_cmd)
-
 
 
 def create_parser():

--- a/flow/visualize/visualizer_rllib.py
+++ b/flow/visualize/visualizer_rllib.py
@@ -271,12 +271,12 @@ def create_parser():
              'class registered in the tune registry. '
              'Required for results trained with flow-0.2.0 and before.')
     parser.add_argument(
-        '--num_rollouts',
+        '--num-rollouts',
         type=int,
         default=1,
         help='The number of rollouts to visualize.')
     parser.add_argument(
-        '--emission_to_csv',
+        '--emission-to-csv',
         action='store_true',
         help='Specifies whether to convert the emission file '
              'created by sumo into a csv file')
@@ -286,11 +286,12 @@ def create_parser():
         help='Specifies whether to use the \'evaluate\' reward '
              'for the environment.')
     parser.add_argument(
-        '--render_mode',
+        '--render-mode',
         type=str,
         default='sumo-gui',
         help='Pick the render mode. Options include sumo-web3d, '
-             'rgbd, sumo-gui, and no-render')
+             'rgbd, sumo-gui, and no-render. For more details'
+             'see the visualization tutorial.')
     parser.add_argument(
         '--save_render',
         action='store_true',

--- a/flow/visualize/visualizer_rllib.py
+++ b/flow/visualize/visualizer_rllib.py
@@ -102,15 +102,15 @@ def visualizer_rllib(args):
     sumo_params.emission_path = './test_time_rollout/'
 
     # pick your rendering mode
-    if args.render_mode == 'sumo_web3d':
+    if args.render_mode == 'sumo-web3d':
         sumo_params.num_clients = 2
         sumo_params.render = False
     elif args.render_mode == 'drgb':
         sumo_params.render = 'drgb'
         sumo_params.pxpm = 4
-    elif args.render_mode == 'sumo_gui':
+    elif args.render_mode == 'sumo-gui':
         sumo_params.render = True
-    elif args.render_mode == 'no_render':
+    elif args.render_mode == 'no-render':
         sumo_params.render = False
 
     if args.save_render:
@@ -288,9 +288,9 @@ def create_parser():
     parser.add_argument(
         '--render_mode',
         type=str,
-        default='sumo_gui',
-        help='Pick the render mode. Options include sumo_web3d, '
-             'rgbd, sumo_gui, and no_render')
+        default='sumo-gui',
+        help='Pick the render mode. Options include sumo-web3d, '
+             'rgbd, sumo-gui, and no-render')
     parser.add_argument(
         '--save_render',
         action='store_true',

--- a/tests/fast_tests/test_visualizers.py
+++ b/tests/fast_tests/test_visualizers.py
@@ -24,7 +24,8 @@ class TestVisualizerRLlib(unittest.TestCase):
 
         # run the experiment and check it doesn't crash
         arg_str = '{}/../data/rllib_data/single_agent 1 --num_rollouts 1 ' \
-                  '--no_render --horizon 10'.format(current_path).split()
+                  '--render_mode no_render ' \
+                  '--horizon 10'.format(current_path).split()
         parser = vs_rllib.create_parser()
         pass_args = parser.parse_args(arg_str)
         visualizer_rllib(pass_args)
@@ -41,7 +42,8 @@ class TestVisualizerRLlib(unittest.TestCase):
 
         # run the experiment and check it doesn't crash
         arg_str = '{}/../data/rllib_data/multi_agent 1 --num_rollouts 1 ' \
-                  '--no_render --horizon 10'.format(current_path).split()
+                  '--render_mode no_render ' \
+                  '--horizon 10'.format(current_path).split()
         parser = vs_rllib.create_parser()
         pass_args = parser.parse_args(arg_str)
         visualizer_rllib(pass_args)

--- a/tests/fast_tests/test_visualizers.py
+++ b/tests/fast_tests/test_visualizers.py
@@ -23,8 +23,8 @@ class TestVisualizerRLlib(unittest.TestCase):
         current_path = os.path.realpath(__file__).rsplit('/', 1)[0]
 
         # run the experiment and check it doesn't crash
-        arg_str = '{}/../data/rllib_data/single_agent 1 --num_rollouts 1 ' \
-                  '--render_mode no_render ' \
+        arg_str = '{}/../data/rllib_data/single_agent 1 --num-rollouts 1 ' \
+                  '--render-mode no-render ' \
                   '--horizon 10'.format(current_path).split()
         parser = vs_rllib.create_parser()
         pass_args = parser.parse_args(arg_str)
@@ -41,8 +41,8 @@ class TestVisualizerRLlib(unittest.TestCase):
         current_path = os.path.realpath(__file__).rsplit('/', 1)[0]
 
         # run the experiment and check it doesn't crash
-        arg_str = '{}/../data/rllib_data/multi_agent 1 --num_rollouts 1 ' \
-                  '--render_mode no_render ' \
+        arg_str = '{}/../data/rllib_data/multi_agent 1 --num-rollouts 1 ' \
+                  '--render-mode no-render ' \
                   '--horizon 10'.format(current_path).split()
         parser = vs_rllib.create_parser()
         pass_args = parser.parse_args(arg_str)

--- a/tutorials/tutorial04_visualize.ipynb
+++ b/tutorials/tutorial04_visualize.ipynb
@@ -182,7 +182,7 @@
    "outputs": [],
    "source": [
     "# --emission_to_csv does the same as above\n",
-    "! python ../../flow/visualize/visualizer_rllib.py results/sample_checkpoint 1 --emission_to_csv"
+    "! python ../../flow/visualize/visualizer_rllib.py results/sample_checkpoint 1 --emission-to-csv"
    ]
   },
   {


### PR DESCRIPTION
Adds flag save_render to visuallizer_rllib which enables you to save the render as a movie in the ~/flow_movies folder. 
Changes naming scheme in PygletRenderer to be easier to parse. 
Adds drgb option to visuallizer_rllib. 