### PR TITLE
Replace slowDown with setSpeed in base env [Merge only if this makes sense]

### DIFF
--- a/flow/envs/base_env.py
+++ b/flow/envs/base_env.py
@@ -667,7 +667,11 @@ class Env(*classdef):
             if acc[i] is not None:
                 this_vel = self.vehicles.get_speed(vid)
                 next_vel = max([this_vel + acc[i] * self.sim_step, 0])
-                self.traci_connection.vehicle.setSpeed(vid, next_vel)
+                speed_mode = self.traci_connection.vehicle.getSpeedMode(vid)
+                if speed_mode == 0:
+                    self.traci_connection.vehicle.setSpeed(vid, next_vel)
+                else:
+                    self.traci_connection.vehicle.slowDown(vid, next_vel, 1)
 
     def apply_lane_change(self, veh_ids, direction):
         """Apply an instantaneous lane-change to a set of vehicles.

--- a/flow/envs/base_env.py
+++ b/flow/envs/base_env.py
@@ -667,7 +667,7 @@ class Env(*classdef):
             if acc[i] is not None:
                 this_vel = self.vehicles.get_speed(vid)
                 next_vel = max([this_vel + acc[i] * self.sim_step, 0])
-                self.traci_connection.vehicle.slowDown(vid, next_vel, 1)
+                self.traci_connection.vehicle.setSpeed(vid, next_vel)
 
     def apply_lane_change(self, veh_ids, direction):
         """Apply an instantaneous lane-change to a set of vehicles.


### PR DESCRIPTION
Replacing `slowDown` with `setSpeed` in base env is required for `speed_mode=0` to be truly _all checks off_. 

**TL;DR** Merge this ONLY IF we think there should not be any fail-safe mechanism under speed mode zero. My personal preference is to merge this, as this is consistent with the literal definition of zero speed mode. Plus, users who want fail-safe features would not set speed mode to zero anyway.

This is because that `slowDown` will issue an emergency braking of -9 m/s2 when the vehicle is about to collide (even if the speed mode is set to zero), while `setSpeed` will _faithfully and immediately_ execute the prescribed speed under speed mode zero (even if the command will result in a collision). 

Besides, under all other speed modes, the two commands seem to be interchangeable. `slowDown` with a 1 ms execution time and `setSpeed` seem to be behave exactly the same if there is no emergent collision. 

As a last corner case, they two commands are almost the same in speed mode zero, with `slowDown` setting a speed _slightly_ smaller (like 0.01 m/s) than the target speed.