### PR TITLE
Small fix to rllib visualizer

### DIFF
--- a/flow/visualize/visualizer_rllib.py
+++ b/flow/visualize/visualizer_rllib.py
@@ -148,8 +148,7 @@ def visualizer_rllib(args):
 
     # create the agent that will be used to compute the actions
     agent = agent_cls(env=env_name, config=config)
-    checkpoint = result_dir + '/checkpoint_' + args.checkpoint_num
-    checkpoint = checkpoint + '/checkpoint-' + args.checkpoint_num
+    checkpoint = result_dir + '/checkpoint-' + args.checkpoint_num
     agent.restore(checkpoint)
 
     env = ModelCatalog.get_preprocessor_as_wrapper(env_class(


### PR DESCRIPTION
Checkpoint files (from RLlib experiments) used to be written to `~/ray_results/experiment_tag/Scenario/checkpoint_N/checkpoint_N.something`, but now they seem to be written to `~/ray_results/experiment_tag/Scenario/checkpoint_N.something`. This PR change reflects that change in directory structure, for when we try to visualize from the checkpoint.

@eugenevinitsky @fywu85 @AboudyKreidieh Could you confirm this?