### PR TITLE
downgrade tensorflow version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
     - six==1.11.0
     - path.py
     - python-dateutil==2.7.3
-    - tensorflow==1.10.0
+    - tensorflow==1.9.0
     - cloudpickle==0.5.3
     - opencv
     - setuptools==39.1.0


### PR DESCRIPTION
Downgrades tensorflow version in requirements to 1.9.0 (to be compatible with OSX El Capitan). 

Addresses #335 at suggestion of @eugenevinitsky: We should be able to merge this if it passes the Travis tests.