### PR TITLE
files for capacity diagram generation

### DIFF
--- a/examples/sumo/bottlenecks.py
+++ b/examples/sumo/bottlenecks.py
@@ -71,7 +71,8 @@ class BottleneckDensityExperiment(Experiment):
                 ret += reward
                 ret_list.append(reward)
 
-                step_outflow = self.env.get_bottleneck_outflow_vehicles_per_hour(20)
+                env = self.env
+                step_outflow = env.get_bottleneck_outflow_vehicles_per_hour(20)
                 density = self.env.get_bottleneck_density()
 
                 step_outflows.append(step_outflow)
@@ -82,7 +83,8 @@ class BottleneckDensityExperiment(Experiment):
             vels.append(vel)
             mean_densities.append(sum(step_densities[100:]) /
                                   (num_steps - 100))
-            outflow = self.env.get_bottleneck_outflow_vehicles_per_hour(10000)
+            env = self.env
+            outflow = env.get_bottleneck_outflow_vehicles_per_hour(10000)
             mean_outflows.append(outflow)
             mean_rets.append(np.mean(ret_list))
             ret_lists.append(ret_list)

--- a/examples/sumo/bottlenecks.py
+++ b/examples/sumo/bottlenecks.py
@@ -1,4 +1,5 @@
 """File demonstrating formation of congestion in bottleneck."""
+
 from flow.core.params import SumoParams, EnvParams, NetParams, InitialConfig, \
     InFlows, SumoLaneChangeParams, SumoCarFollowingParams
 from flow.core.params import VehicleParams
@@ -9,6 +10,9 @@ from flow.controllers import SimLaneChangeController, ContinuousRouter
 from flow.envs.bottleneck_env import BottleneckEnv
 from flow.core.experiment import Experiment
 
+import logging
+
+import numpy as np
 SCALING = 1
 DISABLE_TB = True
 # If set to False, ALINEA will control the ramp meter
@@ -16,7 +20,95 @@ DISABLE_RAMP_METER = True
 INFLOW = 1800
 
 
-def bottleneck_example(flow_rate, horizon, render=None):
+class BottleneckDensityExperiment(Experiment):
+
+    def __init__(self, env):
+        super().__init__(env)
+
+    def run(self, num_runs, num_steps, rl_actions=None, convert_to_csv=False):
+        """Runs the given scenario for num_runs and num_steps per run.
+
+        Parameters
+        ----------
+        num_runs: int
+            number of runs the experiment should perform
+        num_steps: int
+            number of steps to be performs in each run of the experiment
+        rl_actions: list or numpy ndarray, optional
+            actions to be performed by rl vehicles in the network (if there are
+            any)
+        convert_to_csv: bool
+            Specifies whether to convert the emission file created by sumo into
+            a csv file
+        """
+
+        info_dict = {}
+        if rl_actions is None:
+
+            def rl_actions(*_):
+                return None
+
+        rets = []
+        mean_rets = []
+        ret_lists = []
+        vels = []
+        mean_vels = []
+        std_vels = []
+        mean_densities = []
+        mean_outflows = []
+        for i in range(num_runs):
+            vel = np.zeros(num_steps)
+            logging.info('Iter #' + str(i))
+            ret = 0
+            ret_list = []
+            step_outflows = []
+            step_densities = []
+            vehicles = self.env.vehicles
+            state = self.env.reset()
+            for j in range(num_steps):
+                state, reward, done, _ = self.env.step(rl_actions(state))
+                vel[j] = np.mean(vehicles.get_speed(vehicles.get_ids()))
+                ret += reward
+                ret_list.append(reward)
+
+                step_outflow = self.env.get_bottleneck_outflow(20)
+                density = self.env.get_bottleneck_density()
+
+                step_outflows.append(step_outflow)
+                step_densities.append(density)
+                if done:
+                    break
+            rets.append(ret)
+            vels.append(vel)
+            mean_densities.append(sum(step_densities[100:]) /
+                                  (num_steps - 100))
+            outflow = self.env.get_bottleneck_outflow(10000)
+            mean_outflows.append(outflow)
+            mean_rets.append(np.mean(ret_list))
+            ret_lists.append(ret_list)
+            mean_vels.append(np.mean(vel))
+            std_vels.append(np.std(vel))
+            print('Round {0}, return: {1}'.format(i, ret))
+
+        info_dict['returns'] = rets
+        info_dict['velocities'] = vels
+        info_dict['mean_returns'] = mean_rets
+        info_dict['per_step_returns'] = ret_lists
+        info_dict['average_outflow'] = np.mean(mean_outflows)
+        info_dict['per_rollout_outflows'] = mean_outflows
+
+        info_dict['average_rollout_density_outflow'] = np.mean(mean_densities)
+
+        print('Average, std return: {}, {}'.format(
+            np.mean(rets), np.std(rets)))
+        print('Average, std speed: {}, {}'.format(
+            np.mean(mean_vels), np.std(std_vels)))
+        self.env.terminate()
+
+        return info_dict
+
+
+def bottleneck_example(flow_rate, horizon, restart_instance=False, render=None):
     """
     Perform a simulation of vehicles on a bottleneck.
 
@@ -42,7 +134,7 @@ def bottleneck_example(flow_rate, horizon, render=None):
         sim_step=0.5,
         render=render,
         overtake_right=False,
-        restart_instance=False)
+        restart_instance=restart_instance)
 
     vehicles = VehicleParams()
 
@@ -105,10 +197,10 @@ def bottleneck_example(flow_rate, horizon, render=None):
 
     env = BottleneckEnv(env_params, sim_params, scenario)
 
-    return Experiment(env)
+    return BottleneckDensityExperiment(env)
 
 
-if __name__ == "__main__":
+if __name__ == '__main__':
     # import the experiment variable
     # inflow, number of steps, binary
     exp = bottleneck_example(INFLOW, 1000, render=True)

--- a/examples/sumo/bottlenecks.py
+++ b/examples/sumo/bottlenecks.py
@@ -71,7 +71,7 @@ class BottleneckDensityExperiment(Experiment):
                 ret += reward
                 ret_list.append(reward)
 
-                step_outflow = self.env.get_bottleneck_outflow(20)
+                step_outflow = self.env.get_bottleneck_outflow_vehicles_per_hour(20)
                 density = self.env.get_bottleneck_density()
 
                 step_outflows.append(step_outflow)
@@ -82,7 +82,7 @@ class BottleneckDensityExperiment(Experiment):
             vels.append(vel)
             mean_densities.append(sum(step_densities[100:]) /
                                   (num_steps - 100))
-            outflow = self.env.get_bottleneck_outflow(10000)
+            outflow = self.env.get_bottleneck_outflow_vehicles_per_hour(10000)
             mean_outflows.append(outflow)
             mean_rets.append(np.mean(ret_list))
             ret_lists.append(ret_list)

--- a/examples/sumo/bottlenecks.py
+++ b/examples/sumo/bottlenecks.py
@@ -122,7 +122,7 @@ def bottleneck_example(flow_rate, horizon, restart_instance=False,
     horizon : int
         time horizon
     restart_instance: bool, optional
-        whether to restart the instance
+        whether to restart the instance upon reset
     render: bool, optional
         specifies whether to use the gui during execution
 

--- a/examples/sumo/bottlenecks.py
+++ b/examples/sumo/bottlenecks.py
@@ -26,22 +26,6 @@ class BottleneckDensityExperiment(Experiment):
         super().__init__(env)
 
     def run(self, num_runs, num_steps, rl_actions=None, convert_to_csv=False):
-        """Runs the given scenario for num_runs and num_steps per run.
-
-        Parameters
-        ----------
-        num_runs: int
-            number of runs the experiment should perform
-        num_steps: int
-            number of steps to be performs in each run of the experiment
-        rl_actions: list or numpy ndarray, optional
-            actions to be performed by rl vehicles in the network (if there are
-            any)
-        convert_to_csv: bool
-            Specifies whether to convert the emission file created by sumo into
-            a csv file
-        """
-
         info_dict = {}
         if rl_actions is None:
 

--- a/examples/sumo/bottlenecks.py
+++ b/examples/sumo/bottlenecks.py
@@ -108,7 +108,8 @@ class BottleneckDensityExperiment(Experiment):
         return info_dict
 
 
-def bottleneck_example(flow_rate, horizon, restart_instance=False, render=None):
+def bottleneck_example(flow_rate, horizon, restart_instance=False,
+                       render=None):
     """
     Perform a simulation of vehicles on a bottleneck.
 
@@ -118,6 +119,8 @@ def bottleneck_example(flow_rate, horizon, restart_instance=False, render=None):
         total inflow rate of vehicles into the bottleneck
     horizon : int
         time horizon
+    restart_instance: bool, optional
+        whether to restart the instance
     render: bool, optional
         specifies whether to use the gui during execution
 

--- a/examples/sumo/density_exp.py
+++ b/examples/sumo/density_exp.py
@@ -1,0 +1,65 @@
+"""
+Run density experiment to generate capacity diagram for the
+bottleneck experiment
+"""
+
+import multiprocessing
+import numpy as np
+import os
+import ray
+
+from examples.sumo.bottlenecks import bottleneck_example
+
+
+@ray.remote
+def run_bottleneck(flow_rate, num_trials, num_steps, render=None):
+    print('Running experiment for inflow rate: ', flow_rate, render)
+    exp = bottleneck_example(flow_rate, num_steps, restart_instance=True)
+    info_dict = exp.run(num_trials, num_steps)
+
+    return info_dict['average_outflow'], \
+           np.mean(info_dict['velocities']), \
+           np.mean(info_dict['average_rollout_density_outflow']), \
+           info_dict['per_rollout_outflows'], \
+           flow_rate
+
+
+if __name__ == '__main__':
+    # import the experiment variable`
+    densities = list(range(400, 3000, 100))
+    outflows = []
+    velocities = []
+    bottleneckdensities = []
+
+    per_step_densities = []
+    per_step_avg_velocities = []
+    per_step_outflows = []
+
+    rollout_inflows = []
+    rollout_outflows = []
+
+    num_cpus = multiprocessing.cpu_count()
+    ray.init(num_cpus=max(num_cpus - 2, 1))
+    bottleneck_outputs = [run_bottleneck.remote(d, 10, 2000)
+                          for d in densities]
+    for output in ray.get(bottleneck_outputs):
+        outflow, velocity, bottleneckdensity, \
+        per_rollout_outflows, flow_rate = output
+        for i, _ in enumerate(per_rollout_outflows):
+            rollout_outflows.append(per_rollout_outflows[i])
+            rollout_inflows.append(flow_rate)
+        outflows.append(outflow)
+        velocities.append(velocity)
+        bottleneckdensities.append(bottleneckdensity)
+
+    path = os.path.dirname(os.path.abspath(__file__))
+    np.savetxt(path + '/../../data/rets.csv',
+               np.matrix([densities,
+                          outflows,
+                          velocities,
+                          bottleneckdensities]).T,
+               delimiter=',')
+    np.savetxt(path + '/../../data/inflows_outflows.csv',
+               np.matrix([rollout_inflows,
+                          rollout_outflows]).T,
+               delimiter=',')

--- a/examples/sumo/density_exp.py
+++ b/examples/sumo/density_exp.py
@@ -18,10 +18,10 @@ def run_bottleneck(flow_rate, num_trials, num_steps, render=None):
     info_dict = exp.run(num_trials, num_steps)
 
     return info_dict['average_outflow'], \
-           np.mean(info_dict['velocities']), \
-           np.mean(info_dict['average_rollout_density_outflow']), \
-           info_dict['per_rollout_outflows'], \
-           flow_rate
+        np.mean(info_dict['velocities']), \
+        np.mean(info_dict['average_rollout_density_outflow']), \
+        info_dict['per_rollout_outflows'], \
+        flow_rate
 
 
 if __name__ == '__main__':
@@ -44,7 +44,7 @@ if __name__ == '__main__':
                           for d in densities]
     for output in ray.get(bottleneck_outputs):
         outflow, velocity, bottleneckdensity, \
-        per_rollout_outflows, flow_rate = output
+            per_rollout_outflows, flow_rate = output
         for i, _ in enumerate(per_rollout_outflows):
             rollout_outflows.append(per_rollout_outflows[i])
             rollout_inflows.append(flow_rate)

--- a/flow/envs/bottleneck_env.py
+++ b/flow/envs/bottleneck_env.py
@@ -332,6 +332,7 @@ class BottleneckEnv(Env):
             return -1
 
     def get_bottleneck_outflow_vehicles_per_hour(self, sample_period):
+        """Returns the vehs/hour as computed from vehicles that exited during sample_period"""
         return self.vehicles.get_outflow_rate(sample_period)
 
     def get_bottleneck_density(self, lanes=None):

--- a/flow/envs/bottleneck_env.py
+++ b/flow/envs/bottleneck_env.py
@@ -332,7 +332,7 @@ class BottleneckEnv(Env):
             return -1
 
     def get_bottleneck_outflow_vehicles_per_hour(self, sample_period):
-        """Returns the vehs/hour as computed from vehicles that exited during sample_period"""
+        """Returns the vehs/hour based on sample_period"""
         return self.vehicles.get_outflow_rate(sample_period)
 
     def get_bottleneck_density(self, lanes=None):

--- a/flow/envs/bottleneck_env.py
+++ b/flow/envs/bottleneck_env.py
@@ -332,7 +332,7 @@ class BottleneckEnv(Env):
             return -1
 
     def get_bottleneck_outflow_vehicles_per_hour(self, sample_period):
-        """Returns the vehs/hour based on sample_period"""
+        """Return the vehs/hour based on sample_period."""
         return self.vehicles.get_outflow_rate(sample_period)
 
     def get_bottleneck_density(self, lanes=None):

--- a/flow/visualize/capacity_diagram_generator.py
+++ b/flow/visualize/capacity_diagram_generator.py
@@ -1,0 +1,48 @@
+"""Generates capacity diagrams for the bottleneck"""
+
+import csv
+from matplotlib import pyplot as plt
+from matplotlib import rc
+import numpy as np
+import os
+
+rc('text', usetex=True)
+font = {'weight': 'bold',
+        'size': 18}
+rc('font', **font)
+
+inflows = []
+outflows = []
+path = os.path.dirname(os.path.abspath(__file__))
+with open(path + '/../../data/inflows_outflows.csv', 'rt') as csvfile:
+    spamreader = csv.reader(csvfile)
+    for row in spamreader:
+        inflows.append(float(row[0]))
+        outflows.append(float(row[1]))
+
+unique_inflows = sorted(list(set(inflows)))
+sorted_outflows = {inflow: [] for inflow in unique_inflows}
+
+for inflow, outlfow in zip(inflows, outflows):
+    sorted_outflows[inflow].append(outlfow)
+
+mean_outflows = np.asarray([np.mean(sorted_outflows[inflow])
+                            for inflow in unique_inflows])
+min_outflows = np.asarray([np.min(sorted_outflows[inflow])
+                           for inflow in unique_inflows])
+max_outflows = np.asarray([np.max(sorted_outflows[inflow])
+                           for inflow in unique_inflows])
+std_outflows = np.asarray([np.std(sorted_outflows[inflow])
+                           for inflow in unique_inflows])
+
+plt.figure(figsize=(27, 9))
+
+plt.plot(unique_inflows, mean_outflows, linewidth=2, color='orange')
+plt.fill_between(unique_inflows, mean_outflows - std_outflows,
+                 mean_outflows + std_outflows, alpha=0.25, color='orange')
+plt.xlabel('Inflow' + r'$ \ \frac{vehs}{hour}$')
+plt.ylabel('Outflow' + r'$ \ \frac{vehs}{hour}$')
+plt.tick_params(labelsize=20)
+plt.rcParams['xtick.minor.size'] = 20
+plt.minorticks_on()
+plt.show()


### PR DESCRIPTION
- adds a bottleneck experiment that saves the inflow-outflow pairs
- adds a file to run the bottleneck experiment
- adds a file to actually create the capacity diagram from saved data

All code written by @kanaadp and is merely split off from a larger PR that will be merged when new_sumo is ready. 