### PR TITLE
Upgrade autoscaler script to simplify change process

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
         - cached_property
         - joblib==0.10.3
         - dill
-        - boto3=1.4.8
+        - boto3==1.4.8
         - redis~=2.10.6
         - git+https://github.com/Theano/Theano.git@adfe319ce6b781083d8dc3200fb4481b00853791#egg=Theano
         - git+https://github.com/neocxi/Lasagne.git@484866cf8b38d878e92d521be445968531646bb8#egg=Lasagne

--- a/environment.yml
+++ b/environment.yml
@@ -19,6 +19,7 @@ dependencies:
         - cached_property
         - joblib==0.10.3
         - dill
+        - boto3=1.4.8
         - redis~=2.10.6
         - git+https://github.com/Theano/Theano.git@adfe319ce6b781083d8dc3200fb4481b00853791#egg=Theano
         - git+https://github.com/neocxi/Lasagne.git@484866cf8b38d878e92d521be445968531646bb8#egg=Lasagne

--- a/scripts/ray_autoscale.yaml
+++ b/scripts/ray_autoscale.yaml
@@ -39,8 +39,8 @@ auth:
 # For more documentation on available fields, see:
 # http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
 head_node:
-    InstanceType: m4.16xlarge #c4.4xlarge
-    ImageId: ami-04b53bf506e95394f # Flow AMI (Ubuntu)
+    InstanceType: c4.4xlarge
+    ImageId: ami-082a5535a684b1962 # Flow AMI (Ubuntu)
     InstanceMarketOptions:
         MarketType: spot
          #Additional options can be found in the boto docs, e.g.
@@ -54,8 +54,8 @@ head_node:
 # For more documentation on available fields, see:
 # http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
 worker_nodes:
-    InstanceType: m4.16xlarge #c4.4xlarge
-    ImageId: ami-04b53bf506e95394f # Flow AMI (Ubuntu)
+    InstanceType: c4.4xlarge
+    ImageId: ami-082a5535a684b1962 # Flow AMI (Ubuntu)
 
     #Run workers on spot by default. Comment this out to use on-demand.
     InstanceMarketOptions:
@@ -68,13 +68,26 @@ worker_nodes:
 
 file_mounts: {
 # path to your repo and the desired branch name
-"/tmp/path": "<PATH TO FLOW>.git/refs/heads/<BRANCH NAME>",
+#"/tmp/path": "<PATH TO FLOW>.git/refs/heads/<BRANCH NAME>",
+"/tmp/path": "/Users/eugenevinitsky/Desktop/Research/Bayen/Code/flow/.git/refs/heads/autoscaler_fix"
 }
 
 setup_commands:
     # checkout your desired branch on all worker nodes
     - cd flow && git fetch && git checkout `cat /tmp/path`
-    - cd ray && git fetch eugene_upstream && git checkout eugene_upstream/master && git pull eugene_upstream master
+    # set up ray by pip installing and copying over rllib folder
+    - pip install ray==0.6.1
+    - pushd $HOME
+    -     git clone https://github.com/flow-project/ray.git
+    -     cd ray && git fetch && git checkout master && cd ..
+    -     pushd ray
+    -         RAY_SITE_DIR=`python -c "import ray; print(ray.__path__[0])"`
+    -         rm -rf $RAY_SITE_DIR/rllib
+    -         ls $RAY_SITE_DIR
+    -         cp -r python/ray/rllib $RAY_SITE_DIR/rllib
+    -     popd
+    - popd
+    # - cd ray && git fetch origin && git checkout master && git pull origin master
     - echo 'export PATH="/home/ubuntu/sumo/bin:$PATH"' >> ~/.bashrc
     - echo 'export SUMO_HOME="/home/ubuntu/sumo"' >> ~/.bashrc
     - echo 'export PYTHONPATH="/home/ubuntu/sumo/tools:$PYTHONPATH"' >> ~/.bashrc

--- a/scripts/ray_autoscale.yaml
+++ b/scripts/ray_autoscale.yaml
@@ -68,8 +68,8 @@ worker_nodes:
 
 setup_commands:
     # checkout your desired branch on all worker nodes
-    - cd flow && git fetch && git checkout master && git pull origin master # <BRANCH NAME>
-    # set up ray by pip installing and copying over rllib folder
+    - cd flow && git fetch && git checkout master && git pull origin master
+    # set up ray by pip installing and copying over rllib and tune folder
     - pip install --upgrade pyzmq notebook
     - pip install ray==0.6.1
     - pip install lz4
@@ -79,7 +79,7 @@ setup_commands:
     - cd ray && cp -r python/ray/rllib /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/rllib
     - rm -rf /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/tune
     - cd ray && cp -r python/ray/tune /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/tune
-    # - cd ray && git fetch origin && git checkout master && git pull origin master
+    # set up sumo and anaconda
     - echo 'export PATH="/home/ubuntu/sumo/bin:$PATH"' >> ~/.bashrc
     - echo 'export SUMO_HOME="/home/ubuntu/sumo"' >> ~/.bashrc
     - echo 'export PYTHONPATH="/home/ubuntu/sumo/tools:$PYTHONPATH"' >> ~/.bashrc

--- a/scripts/ray_autoscale.yaml
+++ b/scripts/ray_autoscale.yaml
@@ -40,7 +40,7 @@ auth:
 # http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
 head_node:
     InstanceType: c4.4xlarge
-    ImageId: ami-082a5535a684b1962 # Flow AMI (Ubuntu)
+    ImageId: ami-0067051ba5c8f0b64 # Flow AMI (Ubuntu)
     InstanceMarketOptions:
         MarketType: spot
          #Additional options can be found in the boto docs, e.g.
@@ -55,7 +55,7 @@ head_node:
 # http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
 worker_nodes:
     InstanceType: c4.4xlarge
-    ImageId: ami-082a5535a684b1962 # Flow AMI (Ubuntu)
+    ImageId: ami-0067051ba5c8f0b64 # Flow AMI (Ubuntu)
 
     #Run workers on spot by default. Comment this out to use on-demand.
     InstanceMarketOptions:
@@ -66,27 +66,19 @@ worker_nodes:
 
     # Additional options in the boto docs.
 
-file_mounts: {
-# path to your repo and the desired branch name
-#"/tmp/path": "<PATH TO FLOW>.git/refs/heads/<BRANCH NAME>",
-"/tmp/path": "/Users/eugenevinitsky/Desktop/Research/Bayen/Code/flow/.git/refs/heads/autoscaler_fix"
-}
-
 setup_commands:
     # checkout your desired branch on all worker nodes
-    - cd flow && git fetch && git checkout `cat /tmp/path`
+    - cd flow && git fetch && git checkout master && git pull origin master # <BRANCH NAME>
     # set up ray by pip installing and copying over rllib folder
+    - pip install --upgrade pyzmq notebook
     - pip install ray==0.6.1
-    - pushd $HOME
-    -     git clone https://github.com/flow-project/ray.git
-    -     cd ray && git fetch && git checkout master && cd ..
-    -     pushd ray
-    -         RAY_SITE_DIR=`python -c "import ray; print(ray.__path__[0])"`
-    -         rm -rf $RAY_SITE_DIR/rllib
-    -         ls $RAY_SITE_DIR
-    -         cp -r python/ray/rllib $RAY_SITE_DIR/rllib
-    -     popd
-    - popd
+    - pip install lz4
+    - git clone https://github.com/flow-project/ray.git
+    - cd ray && pwd && ls && git fetch && git checkout centralized_vf_pr
+    - rm -rf /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/rllib
+    - cd ray && cp -r python/ray/rllib /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/rllib
+    - rm -rf /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/tune
+    - cd ray && cp -r python/ray/tune /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/tune
     # - cd ray && git fetch origin && git checkout master && git pull origin master
     - echo 'export PATH="/home/ubuntu/sumo/bin:$PATH"' >> ~/.bashrc
     - echo 'export SUMO_HOME="/home/ubuntu/sumo"' >> ~/.bashrc

--- a/scripts/ray_autoscale.yaml
+++ b/scripts/ray_autoscale.yaml
@@ -68,13 +68,13 @@ worker_nodes:
 
 setup_commands:
     # checkout your desired branch on all worker nodes
-    - cd flow && git fetch && git checkout master && git pull origin master
+    - cd flow && git fetch && git checkout itsc_bottleneck
     # set up ray by pip installing and copying over rllib and tune folder
     - pip install --upgrade pyzmq notebook
     - pip install ray==0.6.1
     - pip install lz4
     - git clone https://github.com/flow-project/ray.git
-    - cd ray && pwd && ls && git fetch && git checkout centralized_vf_pr
+    - cd ray && git fetch && git checkout master
     - rm -rf /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/rllib
     - cd ray && cp -r python/ray/rllib /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/rllib
     - rm -rf /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/tune


### PR DESCRIPTION
Previous AMI came with ray pre-built on the machine, but this would cause errors whenever Ray had a merge conflict. Now the autoscaler pip installs ray, clones our version of Ray onto the machine, and then replaces rllib and tune