### PR TITLE
Patch visualizer_rllib for ray 0.6.1.

### DIFF
--- a/flow/visualize/visualizer_rllib.py
+++ b/flow/visualize/visualizer_rllib.py
@@ -25,6 +25,7 @@ except ImportError:
     from ray.rllib.agents.registry import get_agent_class
 from ray.tune.registry import register_env
 from ray.rllib.models import ModelCatalog
+import gym
 
 import flow.envs
 from flow.core.util import emission_to_csv
@@ -42,6 +43,19 @@ Here the arguments are:
 1 - the number of the checkpoint
 """
 
+class _RLlibPreprocessorWrapper(gym.ObservationWrapper):
+    """Adapts a RLlib preprocessor for use as an observation wrapper."""
+
+    def __init__(self, env, preprocessor):
+        super(_RLlibPreprocessorWrapper, self).__init__(env)
+        self.preprocessor = preprocessor
+
+        from gym.spaces.box import Box
+        self.observation_space = Box(
+            -1.0, 1.0, preprocessor.shape, dtype=np.float32)
+
+    def observation(self, observation):
+        return self.preprocessor.transform(observation)
 
 def visualizer_rllib(args):
     result_dir = args.result_dir if args.result_dir[-1] != '/' \
@@ -166,8 +180,10 @@ def visualizer_rllib(args):
     checkpoint = checkpoint + '/checkpoint-' + args.checkpoint_num
     agent.restore(checkpoint)
 
-    env = ModelCatalog.get_preprocessor_as_wrapper(env_class(
-        env_params=env_params, sim_params=sim_params, scenario=scenario))
+    _env = env_class(
+        env_params=env_params, sumo_params=sumo_params, scenario=scenario)
+    _prep = ModelCatalog.get_preprocessor(_env, options={})
+    env = _RLlibPreprocessorWrapper(_env, _prep)
 
     if multiagent:
         rets = {}

--- a/flow/visualize/visualizer_rllib.py
+++ b/flow/visualize/visualizer_rllib.py
@@ -43,6 +43,7 @@ Here the arguments are:
 1 - the number of the checkpoint
 """
 
+
 class _RLlibPreprocessorWrapper(gym.ObservationWrapper):
     """Adapts a RLlib preprocessor for use as an observation wrapper."""
 
@@ -56,6 +57,7 @@ class _RLlibPreprocessorWrapper(gym.ObservationWrapper):
 
     def observation(self, observation):
         return self.preprocessor.transform(observation)
+
 
 def visualizer_rllib(args):
     result_dir = args.result_dir if args.result_dir[-1] != '/' \

--- a/flow/visualize/visualizer_rllib.py
+++ b/flow/visualize/visualizer_rllib.py
@@ -181,7 +181,7 @@ def visualizer_rllib(args):
     agent.restore(checkpoint)
 
     _env = env_class(
-        env_params=env_params, sumo_params=sumo_params, scenario=scenario)
+        env_params=env_params, sim_params=sim_params, scenario=scenario)
     _prep = ModelCatalog.get_preprocessor(_env, options={})
     env = _RLlibPreprocessorWrapper(_env, _prep)
 


### PR DESCRIPTION
`ModelCatalog.get_preprocessor_as_wrapper()` has been removed in recent ray builds. This patch should enable the visualizer work with recent ray APIs while still maintaining backward suportability. 