### PR TITLE
fix for sims_per_step > 1

### DIFF
--- a/flow/core/kernel/vehicle/traci.py
+++ b/flow/core/kernel/vehicle/traci.py
@@ -812,7 +812,7 @@ class TraCIVehicle(KernelVehicle):
     def apply_acceleration(self, veh_ids, acc):
         """See parent class."""
         for i, vid in enumerate(veh_ids):
-            if acc[i] is not None:
+            if acc[i] is not None and vid in self.get_ids():
                 this_vel = self.get_speed(vid)
                 next_vel = max([this_vel + acc[i] * self.sim_step, 0])
                 self.kernel_api.vehicle.slowDown(vid, next_vel, 1)


### PR DESCRIPTION
bug(kernel/core/vehicle/traci.py): If sims_per_step > 1 then it's possible that a vehicle has left the system when you try and apply the action to it a second time. Hence, you have to check that the vehicle is actually in the system before you apply the action.