### PR TITLE
Modified SimpleGridScenario's gen_custom_start_pos function

### DIFF
--- a/flow/scenarios/grid.py
+++ b/flow/scenarios/grid.py
@@ -575,21 +575,31 @@ class SimpleGridScenario(Scenario):
         grid_array = net_params.additional_params["grid_array"]
         row_num = grid_array["row_num"]
         col_num = grid_array["col_num"]
-        per_edge = int(num_vehicles / (2 * (row_num + col_num)))
+        cars_left = grid_array["cars_left"]
+        cars_right = grid_array["cars_right"]
+        cars_top = grid_array["cars_top"]
+        cars_bot = grid_array["cars_bot"]
+
         start_positions = []
         d_inc = 10
         for i in range(col_num):
             x = 6
-            for k in range(per_edge):
+            for k in range(cars_right):
                 start_positions.append(("right0_{}".format(i), x))
+                x += d_inc
+            x = 6
+            for k in range(cars_left):
                 start_positions.append(("left{}_{}".format(row_num, i), x))
                 x += d_inc
 
         for i in range(row_num):
             x = 6
-            for k in range(per_edge):
-                start_positions.append(("bot{}_0".format(i), x))
+            for k in range(cars_top):
                 start_positions.append(("top{}_{}".format(i, col_num), x))
+                x += d_inc
+            x = 6
+            for k in range(cars_bot):
+                start_positions.append(("bot{}_0".format(i), x))
                 x += d_inc
 
         start_lanes = [0] * len(start_positions)

--- a/tests/setup_scripts.py
+++ b/tests/setup_scripts.py
@@ -374,16 +374,17 @@ def grid_mxn_exp_setup(row_num=1,
     if net_params is None:
         # set default net_params configuration
         total_vehicles = vehicles.num_vehicles
+        num_entries = 2 * row_num + 2 * col_num
         grid_array = {
             "short_length": 100,
             "inner_length": 300,
             "long_length": 3000,
             "row_num": row_num,
             "col_num": col_num,
-            "cars_left": int(total_vehicles / 4),
-            "cars_right": int(total_vehicles / 4),
-            "cars_top": int(total_vehicles / 4),
-            "cars_bot": int(total_vehicles / 4)
+            "cars_left": int(total_vehicles / num_entries),
+            "cars_right": int(total_vehicles / num_entries),
+            "cars_top": int(total_vehicles / num_entries),
+            "cars_bot": int(total_vehicles / num_entries)
         }
 
         additional_net_params = {


### PR DESCRIPTION
Closes #451.

Modified SimpleGridScenario's gen_custom_start_pos function to provide more flexibility on how many vehicles are on the top, bottom, left, and right edges of the grid, and fixes bug described in #451 which averages the total number of vehicles/start edges.