### PR TITLE
Add experimental binder build

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.com/flow-project/flow.svg?branch=master)](https://travis-ci.com/flow-project/flow)
 [![Docs](https://readthedocs.org/projects/flow/badge)](http://flow.readthedocs.org/en/latest/)
 [![Coverage Status](https://coveralls.io/repos/github/flow-project/flow/badge.svg?branch=master)](https://coveralls.io/github/flow-project/flow?branch=master)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/flow-project/flow/binder)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/flow-project/flow/blob/master/LICENSE.md)
 
 # Flow
@@ -16,6 +17,7 @@ See [our website](https://flow-project.github.io/) for more information on the a
 - [Documentation](https://flow.readthedocs.org/en/latest/)
 - [Installation instructions](http://flow.readthedocs.io/en/latest/flow_setup.html)
 - [Tutorials](https://github.com/flow-project/flow/tree/master/tutorials)
+- [Binder Build (beta)](https://mybinder.org/v2/gh/flow-project/flow/binder)
 
 # Technical questions
 


### PR DESCRIPTION
<!--
Thank you for contributing to Flow! Here are a few guidelines that you should please follow so that your pull request gets reviewed more efficiently:

1) Make sure your pull request has a short and relevant title
2) Add relevant labels in the right sidebar (e.g. bug fix, new feature, feature removal, documentation, cleaning, sumo, aimsun...)
3) Fill the following template as accurately as possible
-->

## Pull request information

<!-- 
- Status: "Ready to merge" or "In development"
- Kind of changes: The kind of changes this PR introduces; this should reflect the labels in the sidebar
- Code affected: The general code area(s) affected by the PR (e.g. kernel, scenarios, environments, tests, examples, tutorials...)
- Related PR/issue (optional): Link to related issues, PRs or branches (see https://help.github.com/en/articles/autolinked-references-and-urls for link formatting)
-->

- **Status**: Ready to merge
- **Kind of changes**: Add a logo and a link to an experimental Binder build of the `master`. The build is executed per the specification detailed in the dockerfile linked [here](https://github.com/flow-project/flow/blob/binder/Dockerfile).
- **Code affected**: README.md

---

## Description

<!-- Describe all the changes introduced in this PR; keep it short and informative -->
<!-- If it is a bug fix, describe what the bug was and how you fixed it -->

The Binder build enables running online any jupyter notebooks that do not require opening an external GUI. For now, this includes Tutorial 01 (after changing `sumo-gui` to `sumo`) and Tutorial 03.

Features:
- Run tutorials without local installation.
- Binder build is automatically synced with the master as it develops. Every sync will take about a few hours to complete.
