### PR TITLE
Enable GUI-based unit tests in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_script:
 
 script:
   - python setup.py install
-  - xvfb-run nose2 --with-coverage
+  - xvfb-run --server-args="-screen 0 1024x768x24"  nose2 --with-coverage
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_script:
 
 script:
   - python setup.py install
-  - xvfb-run nose2 --with-coverage
+  - nose2 --with-coverage
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_script:
 
 script:
   - python setup.py install
-  - nose2 --with-coverage
+  - xvfb-run nose2 --with-coverage
 
 after_success:
   - coveralls

--- a/flow/visualize/plot_ray_results.py
+++ b/flow/visualize/plot_ray_results.py
@@ -53,6 +53,7 @@ def plot_progress(filepath, columns):
                   'floats.'.format(__file__, col))
             raise
 
+    plt.ion()
     for col_name, values in data.items():
         plt.plot(values, label=col_name)
     plt.legend()


### PR DESCRIPTION
<!--
Thank you for contributing to Flow! Here are a few guidelines that you should please follow so that your pull request gets reviewed more efficiently:

1) Make sure your pull request has a short and relevant title
2) Add relevant labels in the right sidebar (e.g. bug fix, new feature, feature removal, documentation, cleaning, sumo, aimsun...)
3) Fill the following template as accurately as possible
-->

## Pull request information

<!-- 
- Status: "Ready to merge" or "In development"
- Kind of changes: The kind of changes this PR introduces; this should reflect the labels in the sidebar
- Code affected: The general code area(s) affected by the PR (e.g. kernel, scenarios, environments, tests, examples, tutorials...)
- Related PR/issue (optional): Link to related issues, PRs or branches (see https://help.github.com/en/articles/autolinked-references-and-urls for link formatting)
-->

- **Status**: Ready to merge
- **Kind of changes**: Enable testing GUI programs in headless mode through `xvbf`
- **Code affected**: `.travis.yml`
- **Related PR or issue**: This is the prereq for testing renderer module

---

## Description

<!-- Describe all the changes introduced in this PR; keep it short and informative -->
<!-- If it is a bug fix, describe what the bug was and how you fixed it -->

This PR enables testing GUI-based applications, such as the `pyglet-renderer` and `matlplotlib` routines, in headless travis environment, with the help of a virtual screen buffer `xvbf`. For background information about how this is set up, please refer to this [Travis docs](https://docs.travis-ci.com/user/gui-and-headless-browsers/). 

Note that this PR is required for a more comprehensive testing of the renderer module.

Features:
- GUI-based testing in headless mode.
