### PR TITLE
[do not merge] Update ray_autoscale.yaml

### DIFF
--- a/scripts/ray_autoscale.yaml
+++ b/scripts/ray_autoscale.yaml
@@ -1,7 +1,7 @@
 # cluster.yaml ========================================= 
 
 # An unique identifier for the head node and workers of this cluster.
-cluster_name: test #<YOUR NAME>
+cluster_name: kathy #<YOUR NAME>
 
 # The minimum number of workers nodes to launch in addition to the head
 # node. This number should be >= 0.
@@ -40,8 +40,10 @@ auth:
 # http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
 head_node:
     InstanceType: c4.4xlarge
+    # 04b53bf506e95394f
     #ImageId: ami-060b3311dd2b675ee # Flow AMI (Ubuntu)
-    ImageId: ami-0067051ba5c8f0b64 # Flow AMI (Ubuntu)
+    # ImageId: ami-0067051ba5c8f0b64 # Flow AMI (Ubuntu)
+    ImageId: ami-09ee73f99ee3510b0 # kathy AMI (Ubuntu)
     InstanceMarketOptions:
         MarketType: spot
          #Additional options can be found in the boto docs, e.g.
@@ -75,12 +77,12 @@ setup_commands:
     - pip install --upgrade pyzmq notebook
     - pip install ray==0.6.1
     - pip install lz4
-    - git clone https://github.com/flow-project/ray.git
-    - cd ray && git fetch && git checkout master
+    - cd /home/ubuntu && git clone https://github.com/flow-project/ray.git
+    - cd /home/ubuntu/ray && git fetch && git checkout master
     - rm -rf /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/rllib
-    - cd ray && cp -r python/ray/rllib /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/rllib
+    - cd ray && mkdir -p /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/rllib  && cp -r python/ray/rllib /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/rllib
     - rm -rf /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/tune
-    - cd ray && cp -r python/ray/tune /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/tune
+    - cd /home/ubuntu/ray && cp -r python/ray/tune /home/ubuntu/anaconda3/lib/python3.5/site-packages/ray/tune
     # set up sumo and anaconda
     - echo 'export PATH="/home/ubuntu/sumo/bin:$PATH"' >> ~/.bashrc
     - echo 'export SUMO_HOME="/home/ubuntu/sumo"' >> ~/.bashrc


### PR DESCRIPTION
<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**: in development
- **Kind of changes**: bug fix
- **Related PR or issue**:  #598 

## Description
Update ray_autoscale.yaml. Changes include new AMI and updated setup commands:
- Current default AMI `ami-0067051ba5c8f0b64` does not work. It does not have pyarrow
- I created a new AMI with pyarrow, which is `ami-09ee73f99ee3510b0`, titled 'kathy' for testing purposes. This gets further, and then runs into issues with setup_commands in ray_autoscale.yaml
- I fixed all the path issues (most are simple, just needed to reference `cd ~/ray` as opposed to `cd ray`. 

NOT DONE YET. Now this runs into issues with `head_setup_commands` in ray_autoscale.yaml. I suspect this is a PATHing issue. 
