### PR TITLE
Potential bug in environment step done condition

### DIFF
--- a/flow/envs/base_env.py
+++ b/flow/envs/base_env.py
@@ -310,8 +310,8 @@ class Env(*classdef):
         info : dict
             contains other diagnostic information from the previous action
         """
+        self.time_counter += 1
         for _ in range(self.env_params.sims_per_step):
-            self.time_counter += 1
             self.step_counter += 1
 
             # perform acceleration actions for controlled human-driven vehicles


### PR DESCRIPTION
I find a mismatch with the behaviour of the environment performance related to the environment horizon.
To explain my findings, let's assume we have the following settings:

```
HORIZON = env_params.horizon = 10
warmup_steps = 0
env_params.sims_per_step = 5
sumoparams.sim_step = 0.2
```


In base_env.py we find:

```
class Env:
def step(self, rl_actions):
    for _ in range(self.env_params.sims_per_step):
        self.time_counter += 1
        self.step_counter += 1
        # ...
        # advance the simulation in the simulator by one step
        self.k.simulation.simulation_step()
        # ...
    # ...
    # test if the environment should terminate due to a collision or the
    # time horizon being met
    done = crash or (self.time_counter >= self.env_params.warmup_steps
                 + self.env_params.horizon)
```

One environment step will perform sims_per_step simulation steps with sim_step_size duration in Sumo. (in our example 5*0.2s = 1s).
But the time_counter will be increased by sims_per_step = 5 with every environment step, and the done condition will be met after only 2 environment steps with time_counter = 10.

This will be after 10 sumo simulation steps of sim_step size = 0.2 seconds, which is a sumo time of 2 seconds.
So, the "time" horizon is the total number of sumo simulation steps.


The rrlib visualizer (visualizer_rrlib.py) also runs a number of env_params.horizon environment steps:

```
for _ in range(env_params.horizon):
    ...
    state, reward, done, _ = env.step(action)
```
 
but breaks when done is set.

This behaviour is counterintuitive and most likely undesired. 
Especially when running the sumo examples (e.g. /sumo/merge.py), they call the run method of the experiment class as follows:
```
# run for a set number of rollouts / time steps
exp.run(1, 3600, convert_to_csv=False)
```
with
```
def run(self, num_runs, num_steps, rl_actions=None, convert_to_csv=False):
    """Run the given scenario for a set number of runs and steps per run.

    Parameters
    ----------
    num_runs : int
        number of runs the experiment should perform
    num_steps : int
        number of steps to be performs in each run of the experiment
```
In this example, the env_params.horizon is initialized to inf, resulting in the full number of num_steps environment steps.


I suggest to move the time_counter increment step out of the sims_per_step loop, to create the desired behaviour.

Then, the HORIZON (env_params.horizon) is the environment step  horizon.
In the given example, this coincides with the Sumo simulation time in seconds.

To make things more clear, one could think of renaming the HORIZON parameter to ENV_STEP_HORIZON or make things clear in the comments.

<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**: ? (ready to merge / in development)
- **Kind of changes**: ? (bug fix / new feature / documentation...)
- **Related PR or issue**: ? (optional)

## Description

<!-- Describe all the changes introduced in this PR; keep it short and informative -->
<!-- If it is a bug fix, describe what the bug was and how you fixed it -->

? (general description)
