### PR TITLE
Make travis test for pep8 and docstyle first

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ git:
 
 before_install:
   # install and run pep8 and docstyle tests
-  - pip install flake8 .
   - pip install pydocstyle
+  - pydocstyle --convention numpy
+  - pip install flake8 .
   - flake8 --version
   - flake8 --show-source
-  - pydocstyle --convention numpy
 
   # Setup conda (needed for opencv, ray dependency)
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ git:
   depth: 1
 
 before_install:
-  # run some tests
+  # install and run pep8 and docstyle tests
+  - pip install flake8 .
+  - pip install pydocstyle
   - flake8 --version
   - flake8 --show-source
   - pydocstyle --convention numpy
@@ -46,12 +48,10 @@ before_install:
   - ls ../
 
 install:
-  - pip install flake8 .
   - pip install coveralls
   - pip install nose
   - pip install matplotlib
   - pip install jupyter
-  - pip install pydocstyle
 
 script:
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ git:
   depth: 1
 
 before_install:
+  # run some tests
+  - flake8 --version
+  - flake8 --show-source
+  - pydocstyle --convention numpy
+
   # Setup conda (needed for opencv, ray dependency)
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
@@ -47,11 +52,6 @@ install:
   - pip install matplotlib
   - pip install jupyter
   - pip install pydocstyle
-
-before_script:
-  - flake8 --version
-  - flake8 --show-source
-  - pydocstyle --convention numpy
 
 script:
   - python setup.py install

--- a/flow/core/kernel/vehicle/aimsun.py
+++ b/flow/core/kernel/vehicle/aimsun.py
@@ -610,6 +610,7 @@ class AimsunKernelVehicle(KernelVehicle):
         return self.__vehicles[veh_id]['type_name']
 
     def get_initial_speed(self, veh_id):
+        """See parent class."""
         return self.__vehicles[veh_id]["initial_speed"]
 
     def get_speed(self, veh_id, error=-1001):
@@ -702,7 +703,7 @@ class AimsunKernelVehicle(KernelVehicle):
         """See parent class."""
         if isinstance(veh_id, (list, np.ndarray)):
             return [self.get_route(veh) for veh in veh_id]
-        return []  # FIXME
+        return [] # FIXME
         # aimsun_id = self._id_flow2aimsun[veh_id]
         # num_secs = self.kernel_api.AKIVehTrackedGetNbSectionsVehiclePath(
         #     aimsun_id)

--- a/flow/core/kernel/vehicle/aimsun.py
+++ b/flow/core/kernel/vehicle/aimsun.py
@@ -610,7 +610,6 @@ class AimsunKernelVehicle(KernelVehicle):
         return self.__vehicles[veh_id]['type_name']
 
     def get_initial_speed(self, veh_id):
-        """See parent class."""
         return self.__vehicles[veh_id]["initial_speed"]
 
     def get_speed(self, veh_id, error=-1001):

--- a/flow/core/kernel/vehicle/aimsun.py
+++ b/flow/core/kernel/vehicle/aimsun.py
@@ -703,7 +703,7 @@ class AimsunKernelVehicle(KernelVehicle):
         """See parent class."""
         if isinstance(veh_id, (list, np.ndarray)):
             return [self.get_route(veh) for veh in veh_id]
-        return [] # FIXME
+        return []  # FIXME
         # aimsun_id = self._id_flow2aimsun[veh_id]
         # num_secs = self.kernel_api.AKIVehTrackedGetNbSectionsVehiclePath(
         #     aimsun_id)


### PR DESCRIPTION
<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**: Ready to merge
- **Kind of changes**: Improvement
- **Related PR or issue**: #633

## Description

<!-- Describe all the changes introduced in this PR; keep it short and informative -->
<!-- If it is a bug fix, describe what the bug was and how you fixed it -->

I just moved the pep8 & pydocstyle installation and testing up before everything else, it didn't seem to cause any problem.

Tests: 
- a docstyle error is detected in 58s ([build](https://travis-ci.com/flow-project/flow/builds/119194809))
- a pep8 error is detected in 1m38s ([build](https://travis-ci.com/flow-project/flow/builds/119195165))

(while before, both took at least ~5min I guess?)

However I don't know how to test for both pep8/docstyle and unit tests without one interrupting the other, but this is already much faster. @cathywu 
