### PR TITLE
Calculation of standard deviation of mean velocity

### DIFF
--- a/flow/core/experiment.py
+++ b/flow/core/experiment.py
@@ -143,7 +143,7 @@ class Experiment:
         print("Average, std return: {}, {}".format(
             np.mean(rets), np.std(rets)))
         print("Average, std speed: {}, {}".format(
-            np.mean(mean_vels), np.std(std_vels)))
+            np.mean(mean_vels), np.std(mean_vels)))
         self.env.terminate()
 
         if convert_to_csv:


### PR DESCRIPTION
I guess this should be the standard deviation of the average velocities of each run?
In the visualizer_rrlib_py, the same calculation is done as:

 `print('Average, std speed: {}, {}'.format(
        np.mean(mean_speed), np.std(mean_speed)))`


Maybe, on top of this, they could all share the same result evaluation methods.

<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**: ? (ready to merge / in development)
- **Kind of changes**: ? (bug fix / new feature / documentation...)
- **Related PR or issue**: ? (optional)

## Description

<!-- Describe all the changes introduced in this PR; keep it short and informative -->
<!-- If it is a bug fix, describe what the bug was and how you fixed it -->

? (general description)
