### PR TITLE
Add padding and docstring to `green_wave_env.k_closest_to_intersection`

### DIFF
--- a/flow/envs/green_wave_env.py
+++ b/flow/envs/green_wave_env.py
@@ -525,7 +525,7 @@ class TrafficLightGridEnv(Env):
 
         # return the ids of the num_closest vehicles closest to the
         # intersection, potentially with ""-padding.
-        pad_lst = [""] * max(0, num_closest - len(veh_ids_ordered))
+        pad_lst = [""] * (num_closest - len(veh_ids_ordered))
         return veh_ids_ordered[:num_closest] + (pad_lst if padding else [])
 
 

--- a/flow/envs/green_wave_env.py
+++ b/flow/envs/green_wave_env.py
@@ -434,8 +434,7 @@ class TrafficLightGridEnv(Env):
                 speed="max")
 
     def k_closest_to_intersection(self, edges, k, padding=False):
-        """Return the vehicle IDs of the k vehicles that are the closest to an
-        intersection in each edge.
+        """Return the vehicle IDs of the k vehicles closest to an intersection.
 
         For each edge in edges, return the ids (veh_id) of the k vehicles
         in edge that are closest to an intersection (the intersection they

--- a/flow/envs/green_wave_env.py
+++ b/flow/envs/green_wave_env.py
@@ -462,8 +462,7 @@ class TrafficLightGridEnv(Env):
             self.k.vehicle.get_ids_by_edge(edges),
             key=self.get_distance_to_intersection)
 
-        # return the ids of the k vehicles closest to the intersection
-        return veh_ids_ordered[:k]
+        return veh_ids_ordered[:k] + [""] * max(0, k - len(veh_ids_ordered))
 
 
 class PO_TrafficLightGridEnv(TrafficLightGridEnv):

--- a/flow/envs/green_wave_env.py
+++ b/flow/envs/green_wave_env.py
@@ -464,7 +464,6 @@ class TrafficLightGridEnv(Env):
 
         Usage
         -----
-
         For example, consider the following network, composed of 4 edges
         whose ids are "edge0", "edge1", "edge2" and "edge3", the numbers
         being vehicles all headed towards intersection x. The id of the vehicle
@@ -500,7 +499,6 @@ class TrafficLightGridEnv(Env):
 
         Returns
         -------
-
         The returned list contains n * k vehicle ids where n is the number of
         edges given as parameters.
 

--- a/flow/envs/green_wave_env.py
+++ b/flow/envs/green_wave_env.py
@@ -433,8 +433,6 @@ class TrafficLightGridEnv(Env):
                 pos="0",
                 speed="max")
 
-    # FIXME it doesn't make sense to pass a list of edges since the function
-    # returns a flattened list with no padding, so we would lose information
     def k_closest_to_intersection(self, edges, k):
         """Return the vehicle IDs of the k vehicles that are the closest to an
         intersection in each edge.

--- a/flow/envs/green_wave_env.py
+++ b/flow/envs/green_wave_env.py
@@ -433,8 +433,8 @@ class TrafficLightGridEnv(Env):
                 pos="0",
                 speed="max")
 
-    def k_closest_to_intersection(self, edges, k, padding=False):
-        """Return the vehicle IDs of the k vehicles closest to an intersection.
+    def get_closest_to_intersection(self, edges, k, padding=False):
+        """Return the IDs of the vehicles that are closest to an intersection.
 
         For each edge in edges, return the ids (veh_id) of the k vehicles
         in edge that are closest to an intersection (the intersection they
@@ -483,17 +483,17 @@ class TrafficLightGridEnv(Env):
 
         And consider the following example calls on the previous network:
 
-        >>> k_closest_to_intersection("edge0", 4)
+        >>> get_closest_to_intersection("edge0", 4)
         ["veh6", "veh5", "veh4", "veh3"]
 
-        >>> k_closest_to_intersection("edge0", 8)
+        >>> get_closest_to_intersection("edge0", 8)
         ["veh6", "veh5", "veh4", "veh3", "veh2", "veh1"]
 
-        >>> k_closest_to_intersection("edge0", 8, padding=True)
+        >>> get_closest_to_intersection("edge0", 8, padding=True)
         ["veh6", "veh5", "veh4", "veh3", "veh2", "veh1", "", ""]
 
-        >>> k_closest_to_intersection(["edge0", "edge1", "edge2", "edge3"], 3,
-                                      padding=True)
+        >>> get_closest_to_intersection(["edge0", "edge1", "edge2", "edge3"],
+                                         3, padding=True)
         ["veh6", "veh5", "veh4", "veh8", "veh7", "", "", "", "", "veh9",
          "veh10", "veh11"]
 
@@ -513,7 +513,8 @@ class TrafficLightGridEnv(Env):
                              .format(k))
 
         if isinstance(edges, list):
-            ids = [self.k_closest_to_intersection(edge, k) for edge in edges]
+            ids = [self.get_closest_to_intersection(edge, k)
+                   for edge in edges]
             # flatten the list and return it
             return [veh_id for sublist in ids for veh_id in sublist]
 

--- a/flow/envs/green_wave_env.py
+++ b/flow/envs/green_wave_env.py
@@ -499,8 +499,9 @@ class TrafficLightGridEnv(Env):
 
         Returns
         -------
-        If n is the number of edges given as parameters, then the returned list
-        contains n * num_closest vehicle IDs.
+        str list
+            If n is the number of edges given as parameters, then the returned
+            list contains n * num_closest vehicle IDs.
 
         Raises
         ------

--- a/flow/envs/green_wave_env.py
+++ b/flow/envs/green_wave_env.py
@@ -433,7 +433,7 @@ class TrafficLightGridEnv(Env):
                 pos="0",
                 speed="max")
 
-    def k_closest_to_intersection(self, edges, k):
+    def k_closest_to_intersection(self, edges, k, padding=False):
         """Return the vehicle IDs of the k vehicles that are the closest to an
         intersection in each edge.
 
@@ -446,7 +446,22 @@ class TrafficLightGridEnv(Env):
         closest to the end of their edges.
 
         If there are less than k vehicles on an edge, the function performs
-        padding by adding empty strings "" instead of vehicle ids.
+        padding by adding empty strings "" instead of vehicle ids if the
+        padding parameter is set to True
+
+        Parameters
+        ----------
+        edges : str | str list
+            id of an edge or list of edge ids
+        k : int (> 0)
+            number of vehicles to consider on each edge
+        padding : bool (default False)
+            if there are less than k vehicles on an edge, perform padding by
+            adding empty strings "" instead of vehicle ids if the padding
+            parameter is set to True (note: leaving padding to False while
+            passing a list of several edges as parameter can lead to
+            information loss since you will not know which edge, if any,
+            contains less than k vehicles)
 
         Usage
         -----
@@ -474,9 +489,13 @@ class TrafficLightGridEnv(Env):
         ["veh6", "veh5", "veh4", "veh3"]
 
         >>> k_closest_to_intersection("edge0", 8)
+        ["veh6", "veh5", "veh4", "veh3", "veh2", "veh1"]
+
+        >>> k_closest_to_intersection("edge0", 8, padding=True)
         ["veh6", "veh5", "veh4", "veh3", "veh2", "veh1", "", ""]
 
-        >>> k_closest_to_intersection(["edge0", "edge1", "edge2", "edge3"], 3)
+        >>> k_closest_to_intersection(["edge0", "edge1", "edge2", "edge3"], 3,
+                                      padding=True)
         ["veh6", "veh5", "veh4", "veh8", "veh7", "", "", "", "", "veh9",
          "veh10", "veh11"]
 
@@ -508,8 +527,9 @@ class TrafficLightGridEnv(Env):
             key=self.get_distance_to_intersection)
 
         # return the ids of the k vehicles closest to the intersection,
-        # with ""-padding.
-        return veh_ids_ordered[:k] + [""] * max(0, k - len(veh_ids_ordered))
+        # potentially with ""-padding.
+        pad_lst = [""] * max(0, k - len(veh_ids_ordered)) if padding else []
+        return veh_ids_ordered[:k] + pad_lst
 
 
 class PO_TrafficLightGridEnv(TrafficLightGridEnv):

--- a/flow/multiagent_envs/traffic_light_grid.py
+++ b/flow/multiagent_envs/traffic_light_grid.py
@@ -119,7 +119,7 @@ class MultiTrafficLightGridPOEnv(PO_TrafficLightGridEnv, MultiEnv):
             local_edge_numbers = []
             for edge in edges:
                 observed_ids = \
-                    self.k_closest_to_intersection(edge, self.num_observed)
+                    self.get_closest_to_intersection(edge, self.num_observed)
                 all_observed_ids.append(observed_ids)
 
                 # check which edges we have so we can always pad in the right

--- a/tests/fast_tests/test_traffic_lights.py
+++ b/tests/fast_tests/test_traffic_lights.py
@@ -195,13 +195,16 @@ class TestPOEnv(unittest.TestCase):
 
         # check bot, right, top, left in that order
         self.assertEqual(
-            self.env.get_closest_to_intersection(c0_edges[0], 3), k_closest[0:2])
+            self.env.get_closest_to_intersection(c0_edges[0], 3),
+            k_closest[0:2])
         self.assertEqual(
-            self.env.get_closest_to_intersection(c0_edges[1], 3), k_closest[2:4])
+            self.env.get_closest_to_intersection(c0_edges[1], 3),
+            k_closest[2:4])
         self.assertEqual(
             len(self.env.get_closest_to_intersection(c0_edges[2], 3)), 0)
         self.assertEqual(
-            self.env.get_closest_to_intersection(c0_edges[3], 3), k_closest[4:6])
+            self.env.get_closest_to_intersection(c0_edges[3], 3),
+            k_closest[4:6])
 
         for veh_id in k_closest:
             self.assertTrue(self.env.k.vehicle.get_edge(veh_id) in c0_edges)

--- a/tests/fast_tests/test_traffic_lights.py
+++ b/tests/fast_tests/test_traffic_lights.py
@@ -191,23 +191,23 @@ class TestPOEnv(unittest.TestCase):
 
         # get the node mapping for node center0
         c0_edges = node_mapping[0][1]
-        k_closest = self.env.k_closest_to_intersection(c0_edges, 3)
+        k_closest = self.env.get_closest_to_intersection(c0_edges, 3)
 
         # check bot, right, top, left in that order
         self.assertEqual(
-            self.env.k_closest_to_intersection(c0_edges[0], 3), k_closest[0:2])
+            self.env.get_closest_to_intersection(c0_edges[0], 3), k_closest[0:2])
         self.assertEqual(
-            self.env.k_closest_to_intersection(c0_edges[1], 3), k_closest[2:4])
+            self.env.get_closest_to_intersection(c0_edges[1], 3), k_closest[2:4])
         self.assertEqual(
-            len(self.env.k_closest_to_intersection(c0_edges[2], 3)), 0)
+            len(self.env.get_closest_to_intersection(c0_edges[2], 3)), 0)
         self.assertEqual(
-            self.env.k_closest_to_intersection(c0_edges[3], 3), k_closest[4:6])
+            self.env.get_closest_to_intersection(c0_edges[3], 3), k_closest[4:6])
 
         for veh_id in k_closest:
             self.assertTrue(self.env.k.vehicle.get_edge(veh_id) in c0_edges)
 
         with self.assertRaises(ValueError):
-            self.env.k_closest_to_intersection(c0_edges, -1)
+            self.env.get_closest_to_intersection(c0_edges, -1)
 
 
 class TestItRuns(unittest.TestCase):


### PR DESCRIPTION
<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**: Read to merge
- **Kind of changes**: New feature & docstring
- **Related PR or issue**: -

## Description

<!-- Describe all the changes introduced in this PR; keep it short and informative -->
<!-- If it is a bug fix, describe what the bug was and how you fixed it -->

Function `green_wave_env.k_closest_to_intersection`:
- completed docstring and added usage examples
- added an optional `padding` argument to not lose information when calling the function on several edges