### PR TITLE
Update flow_setup instructions: Add python setup.py develop

### DIFF
--- a/docs/source/flow_setup.rst
+++ b/docs/source/flow_setup.rst
@@ -123,7 +123,7 @@ sure to enter your conda environment by typing:
 Let’s see some traffic action:
 
 ::
-
+    python setup.py develop
     python examples/sumo/sugiyama.py
 
 Running the following should result in the loading of the SUMO GUI.


### PR DESCRIPTION
<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**: Ready to merge
- **Kind of changes**: Documentation / Installation Instructions

## General Description

Under the "Test Your Installation" section for installing SUMO and Flow:

We need the line "python setup.py develop" for the SUMO GUI to load. Otherwise, we'll get a ModuleNotFound Error.

The line "python setup.py develop" does appear 2 sections afterward (in the optional "Installing Ray RLlib" section). That said, it'd help new users if they didn't have to figure out why there was a ModuleNotFound Error despite following the setup instructions!
