### PR TITLE
Update Installation Instructions

### DIFF
--- a/docs/source/flow_setup.rst
+++ b/docs/source/flow_setup.rst
@@ -46,7 +46,8 @@ script. Be sure to run the below commands from ``/path/to/flow``.
 
     # create a conda environment
     conda env create -f environment.yml
-    source activate flow
+    conda activate flow
+    python setup.py develop
 
 If the conda install fails, you can also install the requirements using pip by calling
 
@@ -118,12 +119,12 @@ sure to enter your conda environment by typing:
 
 ::
 
-    source activate flow
+    conda activate flow
 
 Let’s see some traffic action:
 
 ::
-    python setup.py develop
+    
     python examples/sumo/sugiyama.py
 
 Running the following should result in the loading of the SUMO GUI.
@@ -245,7 +246,7 @@ To run any of the RL examples, make sure to run
 
 ::
 
-    source activate flow
+    conda activate flow
 
 In order to test run an Flow experiment in RLlib, try the following command:
 
@@ -277,26 +278,6 @@ jobs from there.
     pip install boto3
     ray create-or-update scripts/ray_autoscale.yaml
     ray teardown scripts/ray_autoscale.yaml
-
-
-Testing your installation
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-To run any of the RL examples, make sure to run
-
-::
-
-    source activate flow
-
-In order to test run an Flow experiment in rllib, try the following
-command:
-
-::
-
-    python examples/rllib/stabilizing_the_ring.py
-
-If it does not fail, this means that you have Flow properly configured with
-rllib.
 
 
 (Optional) Direct install of SUMO from GitHub

--- a/docs/source/flow_setup.rst
+++ b/docs/source/flow_setup.rst
@@ -123,7 +123,7 @@ sure to enter your conda environment by typing:
 Let’s see some traffic action:
 
 ::
-
+    python setup.py develop
     python examples/sumo/sugiyama.py
 
 Running the following should result in the loading of the SUMO GUI.


### PR DESCRIPTION
**Pull request information**

    Status: Ready to merge
    Kind of changes: bug fix / documentation

**Description**

I've moved the command "python setup.py develop" up to the setup instructions itself (i.e. directly after activating the conda environment).

I've also updated "source activate" and "source deactivate" to "conda activate" and "conda deactivate", since "source" no longer works for Anaconda versions >= 4.6.

Finally, I've deleted the repeated instructions on "Testing your installation" for RLlib. There were two of the same sections for Testing your installation for RLlib, and the content of second one was just a shortened version of the first one.