### PR TITLE
Aimsun communication port no longer hardcoded

### DIFF
--- a/flow/core/kernel/network/aimsun.py
+++ b/flow/core/kernel/network/aimsun.py
@@ -120,7 +120,7 @@ class AimsunKernelNetwork(BaseKernelNetwork):
                 f.write(template_path)
 
         # start the aimsun process
-        aimsun_call = [aimsun_path, "-script", script_path]
+        aimsun_call = [aimsun_path, "-script", script_path, str(self.sim_params.port)]
         self.aimsun_proc = subprocess.Popen(aimsun_call)
 
         # merge types into edges

--- a/flow/core/kernel/simulation/aimsun.py
+++ b/flow/core/kernel/simulation/aimsun.py
@@ -61,9 +61,6 @@ class AimsunKernelSimulation(KernelSimulation):
         a simulation, and creates a class to communicate with the simulation
         via an TCP connection.
         """
-        # FIXME: hack
-        sim_params.port = 9999
-
         # save the simulation step size (for later use)
         self.sim_step = sim_params.sim_step
 

--- a/flow/utils/aimsun/generate.py
+++ b/flow/utils/aimsun/generate.py
@@ -29,6 +29,9 @@ gui.newDoc(os.path.join(config.PROJECT_PATH,
            "EPSG:32601")
 model = gui.getActiveModel()
 
+# HACK: Store port in author
+port_string = sys.argv[1]
+model.setAuthor(port_string)
 
 def generate_net(nodes,
                  edges,

--- a/flow/utils/aimsun/load.py
+++ b/flow/utils/aimsun/load.py
@@ -5,6 +5,7 @@ import json
 
 import flow.config as config
 from flow.utils.aimsun.scripting_api import AimsunTemplate
+import sys
 
 
 def load_network():
@@ -133,6 +134,10 @@ os.remove(file_path)
 print('[load.py] Loading template ' + template_path)
 model = AimsunTemplate(GKSystem, GKGUISystem)
 model.load(template_path)
+
+# HACK: Store port in author
+port_string = sys.argv[1]
+model.setAuthor(port_string)
 
 # collect the simulation parameters
 params_file = 'flow/core/kernel/network/data.json'

--- a/flow/utils/aimsun/run.py
+++ b/flow/utils/aimsun/run.py
@@ -16,7 +16,8 @@ import struct
 from thread import start_new_thread
 import numpy as np
 
-PORT = 9999
+model = GKSystem.getSystem().getActiveModel()
+PORT = int(model.getAuthor())
 entered_vehicles = []
 exited_vehicles = []
 


### PR DESCRIPTION
## Pull request information

- **Status**: ready to merge
- **Kind of changes**: bug fix
- **Related PR or issue**: N/A

## Description

The TCP communication between Aimsun and Flow uses a hardcoded `PORT = 9999`. A consequence of this is that we are unable to use `rllib` for Aimsun scenarios. The process call calling `load.py` and `generate.py` can accept keyword arguments, which the two scripts store under author (a hack to fix a hack). The port number stored in this way can then be read by `run.py`.

Ports are generated by `sumolib.miscutils.getFreeSocketPort()`, which should pose no issues assuming the use-case where we only run Aimsun simulations.