### PR TITLE
Fixed multi-agent open network __done__ bug

### DIFF
--- a/flow/core/kernel/vehicle/traci.py
+++ b/flow/core/kernel/vehicle/traci.py
@@ -68,6 +68,7 @@ class TraCIVehicle(KernelVehicle):
         # number of vehicles to exit the network for every time-step
         self._num_arrived = []
         self._arrived_ids = []
+        self._arrived_rl_ids = []
 
         # whether or not to automatically color vehicles
         try:
@@ -126,8 +127,11 @@ class TraCIVehicle(KernelVehicle):
                 self.kernel_api.vehicle.getSubscriptionResults(veh_id)
         sim_obs = self.kernel_api.simulation.getSubscriptionResults()
 
+        arrived_rl_ids = []
         # remove exiting vehicles from the vehicles class
         for veh_id in sim_obs[tc.VAR_ARRIVED_VEHICLES_IDS]:
+            if veh_id in self.get_rl_ids():
+                arrived_rl_ids.append(veh_id)
             if veh_id in sim_obs[tc.VAR_TELEPORT_STARTING_VEHICLES_IDS]:
                 # this is meant to resolve the KeyError bug when there are
                 # collisions
@@ -137,6 +141,7 @@ class TraCIVehicle(KernelVehicle):
             # haven't been removed already
             if vehicle_obs[veh_id] is None:
                 vehicle_obs.pop(veh_id, None)
+        self._arrived_rl_ids.append(arrived_rl_ids)
 
         # add entering vehicles into the vehicles class
         for veh_id in sim_obs[tc.VAR_DEPARTED_VEHICLES_IDS]:
@@ -165,6 +170,7 @@ class TraCIVehicle(KernelVehicle):
             self._num_arrived.clear()
             self._departed_ids.clear()
             self._arrived_ids.clear()
+            self._arrived_rl_ids.clear()
 
             # add vehicles from a network template, if applicable
             if hasattr(self.master_kernel.network.network,
@@ -484,6 +490,13 @@ class TraCIVehicle(KernelVehicle):
         """See parent class."""
         if len(self._arrived_ids) > 0:
             return self._arrived_ids[-1]
+        else:
+            return 0
+
+    def get_arrived_rl_ids(self):
+        """See parent class."""
+        if len(self._arrived_rl_ids) > 0:
+            return self._arrived_rl_ids[-1]
         else:
             return 0
 

--- a/flow/envs/multiagent/base.py
+++ b/flow/envs/multiagent/base.py
@@ -121,6 +121,11 @@ class MultiEnv(MultiAgentEnv, Env):
         else:
             reward = self.compute_reward(rl_actions, fail=crash)
 
+        for rl_id in self.k.vehicle.get_arrived_rl_ids():
+            done[rl_id] = True
+            reward[rl_id] = 0
+            states[rl_id] = np.zeros(self.observation_space.shape[0])
+
         return states, reward, done, infos
 
     def reset(self, new_inflow_rate=None):


### PR DESCRIPTION
<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**: ready to merge
- **Kind of changes**: bug fix 
- **Related PR or issue**: n/a

## Description

<!-- Describe all the changes introduced in this PR; keep it short and informative -->
<!-- If it is a bug fix, describe what the bug was and how you fixed it -->

This results in a bug when using Flow's MultiEnv with RL vehicles. RLlib expects you to return final states 'done' vehicles. This error was triggered when a crash occurred (i.e. done['__all__'] = True). Two things weren't happening: 1) The env wasn't registering vehicles that had left the system as 'done', because it wasn't properly keeping track of arrived RL vehicles, and 2) Their states weren't being returned.

I added a _arrived_rl_ids variable to traci.py, which simplifies tracking and finishing them.

