### PR TITLE
render to video using sumo-gui

### DIFF
--- a/flow/envs/base.py
+++ b/flow/envs/base.py
@@ -214,7 +214,14 @@ class Env(gym.Env):
             # render a frame
             self.render(reset=True)
         elif self.sim_params.render in [True, False]:
-            pass  # default to sumo-gui (if True) or sumo (if False)
+            # default to sumo-gui (if True) or sumo (if False)
+            if (self.sim_params.render is True) and self.sim_params.save_render:
+                path = os.path.expanduser('~')+'/flow_rendering/'
+                dir_time = time.strftime("%Y-%m-%d-%H%M%S")
+                if not os.path.exists(path):
+                    os.mkdir(path)
+                self.path = path + dir_time
+                os.mkdir(self.path)
         else:
             raise FatalFlowError(
                 'Mode %s is not supported!' % self.sim_params.render)
@@ -670,6 +677,18 @@ class Env(gym.Env):
             # close pyglet renderer
             if self.sim_params.render in ['gray', 'dgray', 'rgb', 'drgb']:
                 self.renderer.close()
+            # generate video
+            elif (self.sim_params.render is True) and self.sim_params.save_render:
+                save_dir = os.path.expanduser('~') + '/flow_movies'
+                images_dir = self.path.split('/')[-1]
+                if not os.path.exists(save_dir):
+                    os.mkdir(save_dir)
+                speedup = 10  # speedup multiplier
+                fps = speedup//self.sim_step
+                os_cmd = "ffmpeg -y -r {fps} -i {path}/frame_%06d.png".format(path=self.path, fps=fps)
+                os_cmd += " -pix_fmt yuv420p " + self.path+"/%s.mp4"%images_dir
+                os_cmd += "&& cp " + self.path+"/%s.mp4 "%images_dir + save_dir + "/"
+                os.system(os_cmd)  # only works in Unix
         except FileNotFoundError:
             # Skip automatic termination. Connection is probably already closed
             print(traceback.format_exc())
@@ -699,6 +718,9 @@ class Env(gym.Env):
                 if len(self.frame_buffer) > buffer_length:
                     self.frame_buffer.pop(0)
                     self.sights_buffer.pop(0)
+        elif (self.sim_params.render is True) and self.sim_params.save_render:
+            # sumo-gui render
+            self.k.kernel_api.gui.screenshot("View #0", self.path+"/frame_%06d.png" % self.time_counter)
 
     def pyglet_render(self):
         """Render a frame using pyglet."""

--- a/flow/envs/base.py
+++ b/flow/envs/base.py
@@ -686,8 +686,8 @@ class Env(gym.Env):
                 speedup = 10  # speedup multiplier
                 fps = speedup//self.sim_step
                 os_cmd = "ffmpeg -y -r {fps} -i {path}/frame_%06d.png".format(path=self.path, fps=fps)
-                os_cmd += " -pix_fmt yuv420p " + self.path+"/%s.mp4"%images_dir
-                os_cmd += "&& cp " + self.path+"/%s.mp4 "%images_dir + save_dir + "/"
+                os_cmd += " -pix_fmt yuv420p " + self.path+"/%s.mp4" % images_dir
+                os_cmd += "&& cp " + self.path+"/%s.mp4 " % images_dir + save_dir + "/"
                 os.system(os_cmd)  # only works in Unix
         except FileNotFoundError:
             # Skip automatic termination. Connection is probably already closed

--- a/flow/visualize/visualizer_rllib.py
+++ b/flow/visualize/visualizer_rllib.py
@@ -117,8 +117,9 @@ def visualizer_rllib(args):
     elif args.render_mode == 'no_render':
         sim_params.render = False
     if args.save_render:
-        sim_params.render = 'drgb'
-        sim_params.pxpm = 4
+        if args.render_mode != 'sumo_gui':
+            sim_params.render = 'drgb'
+            sim_params.pxpm = 4
         sim_params.save_render = True
 
     # Create and register a gym+rllib env

--- a/flow/visualize/visualizer_rllib.py
+++ b/flow/visualize/visualizer_rllib.py
@@ -13,7 +13,6 @@ parser : ArgumentParser
 """
 
 import argparse
-from datetime import datetime
 import gym
 import numpy as np
 import os
@@ -313,23 +312,6 @@ def visualizer_rllib(args):
 
         # delete the .xml version of the emission file
         os.remove(emission_path)
-
-    # if we wanted to save the render, here we create the movie
-    if args.save_render:
-        dirs = os.listdir(os.path.expanduser('~')+'/flow_rendering')
-        # Ignore hidden files
-        dirs = [d for d in dirs if d[0] != '.']
-        dirs.sort(key=lambda date: datetime.strptime(date, "%Y-%m-%d-%H%M%S"))
-        recent_dir = dirs[-1]
-        # create the movie
-        movie_dir = os.path.expanduser('~') + '/flow_rendering/' + recent_dir
-        save_dir = os.path.expanduser('~') + '/flow_movies'
-        if not os.path.exists(save_dir):
-            os.mkdir(save_dir)
-        os_cmd = "cd " + movie_dir + " && ffmpeg -i frame_%06d.png"
-        os_cmd += " -pix_fmt yuv420p " + dirs[-1] + ".mp4"
-        os_cmd += "&& cp " + dirs[-1] + ".mp4 " + save_dir + "/"
-        os.system(os_cmd)
 
 
 def create_parser():


### PR DESCRIPTION
## Pull request information

- **Status**: in development
- **Kind of changes**: new feature
- **Related PR or issue**: #777 

Generates sumo screenshots using `self.k.kernel_api.gui.screenshot("View #0", 'screenshot.png')`.  These screenshots are saved to `~/flow_rendering` by default. These images should be convertible to a video using the `--save_render` argument in `visualizer_rllib.py`, or when passing `save_render=True` to SumoParams.