### PR TITLE
Checked for edge case where vehicle speeds is empty

### DIFF
--- a/flow/visualize/visualizer_rllib.py
+++ b/flow/visualize/visualizer_rllib.py
@@ -204,7 +204,12 @@ def visualizer_rllib(args):
             ret = 0
         for _ in range(env_params.horizon):
             vehicles = env.unwrapped.k.vehicle
-            vel.append(np.mean(vehicles.get_speed(vehicles.get_ids())))
+            speeds = vehicles.get_speed(vehicles.get_ids())
+
+            # only include non-empty speeds
+            if speeds:
+                vel.append(np.mean(speeds))
+
             if multiagent:
                 action = {}
                 for agent_id in state.keys():


### PR DESCRIPTION
<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**: ? ready to merge
- **Kind of changes**: bug_fix
- **Related PR or issue**: ? #794 

## Description
There is an edge case where the get_speed method in the vehicles class returns an empty list.
The mean of an empty list is np.nan. So when the mean of the result is stored in the vel list, nan gets propagated to the mean_speed list. The result is `nan` as the avg speed and std deviation.