### PR TITLE
Make render true by default in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -33,9 +33,9 @@ where `EXP_CONFIG` is the name of the experiment configuration file, as located 
 There are several *optional* arguments that can be added to the above command:
 
 ```shell
- python simulate.py EXP_CONFIG --num_runs n --render --aimsun --gen_emission
+ python simulate.py EXP_CONFIG --num_runs n --no_render --aimsun --gen_emission
 ```
-where `--num_runs` indicates the number of simulations to run (default of `n` is 1), `--render` indicates whether to run the simulation during runtime (default is False), `--aimsun` indicates whether to run the simulation using the simulator Aimsun (the default simulator is SUMO), and `--gen_emission` indicates whether to generate an emission file from the simulation.
+where `--num_runs` indicates the number of simulations to run (default of `n` is 1), `--no_render` indicates whether to deactivate the simulation GUI during runtime (by default simulation GUI is active), `--aimsun` indicates whether to run the simulation using the simulator Aimsun (the default simulator is SUMO), and `--gen_emission` indicates whether to generate an emission file from the simulation.
 
 ## RL examples based on RLlib 
 

--- a/examples/simulate.py
+++ b/examples/simulate.py
@@ -1,7 +1,7 @@
 """Runner script for non-RL simulations in flow.
 
 Usage
-    python simulate.py EXP_CONFIG --render
+    python simulate.py EXP_CONFIG --no_render
 """
 import argparse
 import sys
@@ -19,7 +19,7 @@ def parse_args(args):
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="Parse argument used when running a Flow simulation.",
-        epilog="python simulate.py EXP_CONFIG --num_runs INT --render")
+        epilog="python simulate.py EXP_CONFIG --num_runs INT --no_render")
 
     # required input parameters
     parser.add_argument(
@@ -32,7 +32,7 @@ def parse_args(args):
         '--num_runs', type=int, default=1,
         help='Number of simulations to run. Defaults to 1.')
     parser.add_argument(
-        '--render',
+        '--no_render',
         action='store_true',
         help='Specifies whether to run the simulation during runtime.')
     parser.add_argument(
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     flow_params = getattr(module, flags.exp_config).flow_params
 
     # Update some variables based on inputs.
-    flow_params['sim'].render = flags.render
+    flow_params['sim'].render = not flags.no_render
     flow_params['simulator'] = 'aimsun' if flags.aimsun else 'traci'
 
     # specify an emission path if they are meant to be generated


### PR DESCRIPTION
<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**: Ready to merge
- **Kind of changes**: Enhancement
- **Related PR or issue**: #881, https://stackoverflow.com/questions/59656105/sumo-gui-does-not-open-when-running-flow-examples 

## Description

<!-- Describe all the changes introduced in this PR; keep it short and informative -->
<!-- If it is a bug fix, describe what the bug was and how you fixed it -->

It seems that having the renderer (GUI) off by default is causing some confusion for users. So, this PR will make the rendered True by default (I believe, is more common for our new users to see the GUI)