### PR TITLE
Plotting non-learning data on tensorboard

### DIFF
--- a/examples/exp_configs/rl/singleagent/singleagent_traffic_light_grid.py
+++ b/examples/exp_configs/rl/singleagent/singleagent_traffic_light_grid.py
@@ -160,7 +160,7 @@ vehicles.add(
     veh_id='idm',
     acceleration_controller=(SimCarFollowingController, {}),
     car_following_params=SumoCarFollowingParams(
-        minGap=2.5,
+        min_gap=2.5,
         decel=7.5,  # avoid collisions at emergency stops
         max_speed=V_ENTER,
         speed_mode="all_checks",

--- a/examples/train.py
+++ b/examples/train.py
@@ -172,6 +172,25 @@ def setup_exps_rllib(flow_params,
     return alg_run, gym_name, config
 
 
+
+
+
+def on_episode_step(info):
+    #print(info["episode"].last_info_for())
+
+    episode = info["episode"]
+    customData = episode.last_info_for()
+
+    if customData is not None:
+        #print(customData['average delay'])
+        episode.custom_metrics["average_delay"] = customData['average_delay']
+        episode.custom_metrics["standstill_vehicles"] = customData['standstill_vehicles']
+        episode.custom_metrics["number_RL_commands"] = customData['number_RL_commands']
+        episode.custom_metrics["average_speed"] = customData['average_speed']
+
+
+
+
 if __name__ == "__main__":
     flags = parse_args(sys.argv[1:])
 
@@ -205,7 +224,10 @@ if __name__ == "__main__":
                 "run": alg_run,
                 "env": gym_name,
                 "config": {
-                    **config
+                    **config,
+                    'callbacks': {
+                        "on_episode_step": tune.function(on_episode_step),
+                    }
                 },
                 "checkpoint_freq": 20,
                 "checkpoint_at_end": True,

--- a/flow/envs/base.py
+++ b/flow/envs/base.py
@@ -26,6 +26,9 @@ from flow.core.kernel import Kernel
 from flow.utils.exceptions import FatalFlowError
 
 
+from flow.core import rewards
+
+
 class Env(gym.Env):
     """Base environment class.
 
@@ -395,8 +398,18 @@ class Env(gym.Env):
         done = (self.time_counter >= self.env_params.warmup_steps +
                 self.env_params.horizon)  # or crash
 
+
+
+
+
         # compute the info for each agent
         infos = {}
+
+        infos = {'standstill_vehicles': - rewards.penalize_standstill(self),
+                'average_delay': rewards.min_delay_unscaled(self),
+                'number_RL_commands': rewards.boolean_action_penalty(rl_actions >= 0.5, gain=1.0),
+                'average_speed': rewards.average_velocity(self)}
+
 
         # compute the reward
         if self.env_params.clip_actions:

--- a/flow/envs/traffic_light_grid.py
+++ b/flow/envs/traffic_light_grid.py
@@ -639,7 +639,7 @@ class TrafficLightGridPOEnv(TrafficLightGridEnv):
         """
         tl_box = Box(
             low=0.,
-            high=1,
+            high=5,
             shape=(3 * 4 * self.num_observed * self.num_traffic_lights +
                    2 * len(self.k.network.get_edge_list()) +
                    3 * self.num_traffic_lights,),


### PR DESCRIPTION
- Ready to merge
- New feature added: It is now possible to to plot non-learning data such as SUMO's information (speed, number of standstill vehicles, delay, etc.) on tensorboard
- Related PR: [#736 ](https://github.com/flow-project/flow/issues/736)

## Description

Using the reward class, it is possible to plot non-learning data. As an example, I plot the global delay of the network, the average speed of the vehicles, the number of RL commands sent by the agent and the mean number of standstill vehicles. I do all of this using the reward class ad it displays for each variable the mean, max and min value every X timesteps.
In order to do this, you can add the data to the `infos` variable in `base.py` (environment) and get the information back from the `train.py` from the` on_episode_step()` function.


