### PR TITLE
Multiagent rendering fix

### DIFF
--- a/flow/envs/multiagent/base.py
+++ b/flow/envs/multiagent/base.py
@@ -148,6 +148,13 @@ class MultiEnv(MultiAgentEnv, Env):
         # reset the time counter
         self.time_counter = 0
 
+        # Now that we've passed the possibly fake init steps some rl libraries
+        # do, we can feel free to actually render things
+        if self.should_render:
+            self.sim_params.render = True
+            # got to restart the simulation to make it actually display anything
+            self.restart_simulation(self.sim_params)
+
         # warn about not using restart_instance when using inflows
         if len(self.net_params.inflows.get()) > 0 and \
                 not self.sim_params.restart_instance:


### PR DESCRIPTION
## Pull request information

- **Status**: ? Ready to merge
- **Kind of changes**: Bug fix
- **Related PR or issue**: Addresses part of #860 

## Description

We added self.should_render to the single_agent environments to handle lots of sumo-gui windows opened — wasn't handled it in the multiagent env. This should fix that.
