### PR TITLE
DO NOT MERGE UNTESTED: Done bug

### DIFF
--- a/flow/core/kernel/vehicle/traci.py
+++ b/flow/core/kernel/vehicle/traci.py
@@ -502,10 +502,13 @@ class TraCIVehicle(KernelVehicle):
         else:
             return 0
 
-    def get_arrived_rl_ids(self):
+    def get_arrived_rl_ids(self, k=1):
         """See parent class."""
         if len(self._arrived_rl_ids) > 0:
-            return self._arrived_rl_ids[-1]
+            arrived = []
+            for arr in self._arrived_rl_ids[-k:]:
+                arrived.extend(arr)
+            return arrived
         else:
             return 0
 

--- a/flow/envs/multiagent/base.py
+++ b/flow/envs/multiagent/base.py
@@ -122,7 +122,7 @@ class MultiEnv(MultiAgentEnv, Env):
         else:
             reward = self.compute_reward(rl_actions, fail=crash)
 
-        for rl_id in self.k.vehicle.get_arrived_rl_ids():
+        for rl_id in self.k.vehicle.get_arrived_rl_ids(self.env_params.sims_per_step):
             done[rl_id] = True
             reward[rl_id] = 0
             if isinstance(self.observation_space, Dict):


### PR DESCRIPTION
<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**: in dev
- **Kind of changes**: bug fix
- **Related PR or issue**: ? (optional)

## Description

<!-- Describe all the changes introduced in this PR; keep it short and informative -->
<!-- If it is a bug fix, describe what the bug was and how you fixed it -->

The issue was that some RL vehicles weren't being flagged as "done". This is because multiple sim steps were happening before removing vehicles, BUT at the same time, get_arrived_rl_ids() only returned the arrived vehicles from the latest time step. This allows you to retrieve the arrived vehicles from the k latest time steps. 
