### PR TITLE
changed _departed_ids, and _arrived_ids in the update function

### DIFF
--- a/flow/core/kernel/simulation/traci.py
+++ b/flow/core/kernel/simulation/traci.py
@@ -52,7 +52,8 @@ class TraCISimulation(KernelSimulation):
             tc.VAR_TIME_STEP,
             tc.VAR_DELTA_T,
             tc.VAR_LOADED_VEHICLES_NUMBER,
-            tc.VAR_DEPARTED_VEHICLES_NUMBER
+            tc.VAR_DEPARTED_VEHICLES_NUMBER,
+            tc.VAR_ARRIVED_VEHICLES_NUMBER
         ])
 
     def simulation_step(self):

--- a/flow/core/kernel/vehicle/traci.py
+++ b/flow/core/kernel/vehicle/traci.py
@@ -211,11 +211,10 @@ class TraCIVehicle(KernelVehicle):
                     self.__vehicles[veh_id]["last_lc"] = self.time_counter
 
             # updated the list of departed and arrived vehicles
-            self._num_departed.append(
-                len(sim_obs[tc.VAR_DEPARTED_VEHICLES_IDS]))
-            self._num_arrived.append(len(sim_obs[tc.VAR_ARRIVED_VEHICLES_IDS]))
-            self._departed_ids.append(sim_obs[tc.VAR_DEPARTED_VEHICLES_IDS])
-            self._arrived_ids.append(sim_obs[tc.VAR_ARRIVED_VEHICLES_IDS])
+            self._num_departed.append(sim_obs[tc.VAR_LOADED_VEHICLES_NUMBER])
+            self._num_arrived.append(sim_obs[tc.VAR_ARRIVED_VEHICLES_NUMBER])
+            self._departed_ids = sim_obs[tc.VAR_DEPARTED_VEHICLES_IDS]
+            self._arrived_ids = sim_obs[tc.VAR_ARRIVED_VEHICLES_IDS]
 
             # update the number of not departed vehicles
             self.num_not_departed += sim_obs[tc.VAR_LOADED_VEHICLES_NUMBER] - \
@@ -518,7 +517,7 @@ class TraCIVehicle(KernelVehicle):
     def get_arrived_ids(self):
         """See parent class."""
         if len(self._arrived_ids) > 0:
-            return self._arrived_ids[-1]
+            return self._arrived_ids
         else:
             return 0
 
@@ -532,7 +531,7 @@ class TraCIVehicle(KernelVehicle):
     def get_departed_ids(self):
         """See parent class."""
         if len(self._departed_ids) > 0:
-            return self._departed_ids[-1]
+            return self._departed_ids
         else:
             return 0
 

--- a/flow/core/kernel/vehicle/traci.py
+++ b/flow/core/kernel/vehicle/traci.py
@@ -71,11 +71,11 @@ class TraCIVehicle(KernelVehicle):
 
         # number of vehicles that entered the network for every time-step
         self._num_departed = []
-        self._departed_ids = []
+        self._departed_ids = 0
 
         # number of vehicles to exit the network for every time-step
         self._num_arrived = []
-        self._arrived_ids = []
+        self._arrived_ids = 0
         self._arrived_rl_ids = []
 
         # whether or not to automatically color vehicles
@@ -184,8 +184,8 @@ class TraCIVehicle(KernelVehicle):
                 self.prev_last_lc[veh_id] = -float("inf")
             self._num_departed.clear()
             self._num_arrived.clear()
-            self._departed_ids.clear()
-            self._arrived_ids.clear()
+            self._departed_ids = 0
+            self._arrived_ids = 0
             self._arrived_rl_ids.clear()
             self.num_not_departed = 0
 
@@ -516,10 +516,7 @@ class TraCIVehicle(KernelVehicle):
 
     def get_arrived_ids(self):
         """See parent class."""
-        if len(self._arrived_ids) > 0:
-            return self._arrived_ids
-        else:
-            return 0
+        return self._arrived_ids
 
     def get_arrived_rl_ids(self):
         """See parent class."""
@@ -530,10 +527,7 @@ class TraCIVehicle(KernelVehicle):
 
     def get_departed_ids(self):
         """See parent class."""
-        if len(self._departed_ids) > 0:
-            return self._departed_ids
-        else:
-            return 0
+        return self._departed_ids
 
     def get_num_not_departed(self):
         """See parent class."""


### PR DESCRIPTION
<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**:  ready to merge
- **Kind of changes**: bug fix 
- **Related PR or issue**: 

## Description

<!-- Describe all the changes introduced in this PR; keep it short and informative -->
<!-- If it is a bug fix, describe what the bug was and how you fixed it -->

In vehicle/traci, we are storing all departed and arrived vehicle IDs for each simulation step. Every simulation step we are appending new vehicle list to _departed_ids and _arrived_ids. In large networks or high horizon times, this can be expensive and results in significant slow down. I changed _departed_ids and _arrived_ids to just store the current ids. I didn't totally delete them since we may need them (e.g., as in MultiEnv)