### PR TITLE
Address MacOS Catalina SegFault issue when running sumo-gui

### DIFF
--- a/docs/source/flow_setup.rst
+++ b/docs/source/flow_setup.rst
@@ -112,6 +112,22 @@ If you are a Mac user and the above command gives you the error
 ``FXApp:openDisplay: unable to open display :0.0``, make sure to open the
 application XQuartz.
 
+*Troubleshooting*:
+If you are a Mac user and the above command gives you the error
+``Segmentation fault: 11``, make sure to reinstall ``fox`` using brew.
+::
+
+  # Uninstall Catalina bottle of fox:
+  $ brew uninstall --ignore-dependencies fox
+
+  # Edit brew Formula of fox:
+  $ brew edit fox
+
+  # Comment out or delete the following line: sha256 "c6697be294c9a0458580564d59f8db32791beb5e67a05a6246e0b969ffc068bc" => :catalina
+  # Install Mojave bottle of fox:
+  $ brew install fox
+
+
 Testing your SUMO and Flow installation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**:  (ready to merge)
- **Kind of changes**:  (documentation)
- **Related PR or issue**:  address the sumo-gui segmentation fault in MacOS X Catalina

## Description

Address the sumo-gui segmentation fault in MacOS X Catalina. There is a problem with libfox that let to Segmentation fault: 11.
