### PR TITLE
Control range added, affects reward and state

### DIFF
--- a/examples/exp_configs/rl/multiagent/multiagent_i210.py
+++ b/examples/exp_configs/rl/multiagent/multiagent_i210.py
@@ -52,6 +52,7 @@ additional_env_params.update({
     # whether to reroute vehicles once they have exited
     "reroute_on_exit": True,
     'target_velocity': 18,
+    "control_range": [500, 2300]
 })
 
 # CREATE VEHICLE TYPES AND INFLOWS

--- a/examples/exp_configs/rl/multiagent/multiagent_straight_road.py
+++ b/examples/exp_configs/rl/multiagent/multiagent_straight_road.py
@@ -58,7 +58,8 @@ additional_env_params.update({
     'local_reward': True,
     'lead_obs': True,
     # whether to reroute vehicles once they have exited
-    "reroute_on_exit": True
+    "reroute_on_exit": True,
+    "control_range": [500, 2500]
 })
 
 

--- a/examples/exp_configs/rl/multiagent/multiagent_straight_road.py
+++ b/examples/exp_configs/rl/multiagent/multiagent_straight_road.py
@@ -59,11 +59,11 @@ additional_env_params.update({
     'lead_obs': True,
     # whether to reroute vehicles once they have exited
     "reroute_on_exit": True,
-    "control_range": [500, 2500]
+    "control_range": [500, 2300]
 })
 
 
-# CREATE VEHICLE TYPES AND INFLOWS
+# CREATE VEHICLE TYPES AND INFLOWsS
 
 vehicles = VehicleParams()
 inflows = InFlows()

--- a/flow/controllers/velocity_controllers.py
+++ b/flow/controllers/velocity_controllers.py
@@ -1,6 +1,7 @@
 """Contains a list of custom velocity controllers."""
 
 from flow.controllers.base_controller import BaseController
+from flow.controllers.car_following_models import IDMController
 import numpy as np
 
 
@@ -36,6 +37,7 @@ class FollowerStopper(BaseController):
 
         # maximum achievable acceleration by the vehicle
         self.max_accel = car_following_params.controller_params['accel']
+        self.control_range = car_following_params.controller_params['control_range']
 
         # other parameters
         self.dx_1_0 = 4.5
@@ -104,9 +106,15 @@ class FollowerStopper(BaseController):
 
         if edge == "":
             return None
-        else:
+
+        x_pos = env.k.vehicle.get_x_by_id(self.veh_id)
+        if self.control_range and x_pos >= self.control_range[0] and x_pos <= self.control_range[1]:
             # compute the acceleration from the desired velocity
             return np.clip((v_cmd - this_vel) / env.sim_step, -np.abs(self.max_deaccel), self.max_accel)
+        else: 
+            # return IDM command
+            idm = IDMController(self.veh_id)
+            return idm.get_accel(env)
 
 
 class NonLocalFollowerStopper(FollowerStopper):

--- a/flow/core/params.py
+++ b/flow/core/params.py
@@ -847,6 +847,7 @@ class SumoCarFollowingParams:
             speed_dev=0.1,
             impatience=0.5,
             car_follow_model="IDM",
+            control_range=None,
             **kwargs):
         """Instantiate SumoCarFollowingParams."""
         # check for deprecations (minGap)
@@ -886,6 +887,7 @@ class SumoCarFollowingParams:
             "speedDev": speed_dev,
             "impatience": impatience,
             "carFollowModel": car_follow_model,
+            "control_range": control_range,
         }
 
         # adjust the speed mode value


### PR DESCRIPTION
<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**: in development
- **Kind of changes**: new feach (bug fix / new feature / documentation...)
- **Related PR or issue**: ? (optional)

## Description

<!-- Describe all the changes introduced in this PR; keep it short and informative -->
<!-- If it is a bug fix, describe what the bug was and how you fixed it -->

Added control range. You can sit this via additional env params. Control range only affects get_state and reward. Logic is pretty much just: if veh_id not in the control range, then don't include its info in get_state or compute_reward
