### PR TITLE
Time-Space Diagram greyed regions

### DIFF
--- a/flow/visualize/time_space_diagram.py
+++ b/flow/visualize/time_space_diagram.py
@@ -434,11 +434,11 @@ def plot_tsd(ax, df, segs, args, lane=None, ghost_edges=None, ghost_bounds=None)
         y_domain_max = df[~df['edge_id'].isin(ghost_edges)]['distance'].max()
         rects.append(Rectangle((xmin, y_domain_min), args.start - xmin, y_domain_max - y_domain_min))
         rects.append(Rectangle((xmin, ymin), xmax - xmin, y_domain_min - ymin))
-        rects.append(Rectangle((xmin, y_domain_min + y_domain_max), xmax - xmin, ymax - (y_domain_min + y_domain_max)))
+        rects.append(Rectangle((xmin, y_domain_max), xmax - xmin, ymax - y_domain_max))
     elif ghost_bounds:
         rects.append(Rectangle((xmin, ghost_bounds[0]), args.start - xmin, ghost_bounds[1] - ghost_bounds[0]))
         rects.append(Rectangle((xmin, ymin), xmax - xmin, ghost_bounds[0] - ymin))
-        rects.append(Rectangle((xmin, ghost_bounds[0] + ghost_bounds[1]), xmax - xmin, ymax - (ghost_bounds[0] + ghost_bounds[1])))
+        rects.append(Rectangle((xmin, ghost_bounds[1]), xmax - xmin, ymax - ghost_bounds[1]))
     else:
         rects.append(Rectangle((xmin, ymin), args.start - xmin, ymax - ymin))
 


### PR DESCRIPTION
## Pull request information

- **Status**: ready to merge
- **Kind of changes**: new feature

## Description

This PR allows the time-space diagrams to include a greyed out area over the warmup period and ghost cells. E.g.,

for single-lane straight road:
![flow_858bc7a51d9f4169872cdc41d20a5cba](https://user-images.githubusercontent.com/7437172/86308080-2ca63000-bbcd-11ea-9d5d-a28b8e66e8bc.png)

for I-210 subnetwork without ramps:
![flow_eb49bb434d37433bbb8cf6a37463407f](https://user-images.githubusercontent.com/7437172/86308115-35970180-bbcd-11ea-9651-46ce3ad5300b.png)
