### PR TITLE
Update question Github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -8,7 +8,10 @@ about: If you have a question or run into some problem with Flow (e.g. during th
 PLEASE DO NOT ASK YOUR QUESTIONS HERE ON GITHUB!
 
 If you have a question or run into some problem (e.g. during installation or when running an example)
-with Flow, please direct your technical questions to Stack Overflow using the "flow-project" tag.
+with Flow, please direct technical questions to the Flow project Slack channel here:
 
-link: https://stackoverflow.com/questions/tagged/flow-project
-tag: flow-project
+https://join.slack.com/t/flow-users/shared_invite/enQtODQ0NDYxMTQyNDY2LTY1ZDVjZTljM2U0ODIxNTY5NTQ2MmUxMzYzNzc5NzU4ZTlmNGI2ZjFmNGU4YjVhNzE3NjcwZTBjNzIxYTg5ZmY
+
+If you have a non-technical inquiry, please send us an email:
+
+https://flow-project.github.io/contact.html


### PR DESCRIPTION
Update question Github issue template to refer people to Slack channel, and not StackOverflow

<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**: ready to merge
- **Kind of changes**: new feature

## Description

<!-- Describe all the changes introduced in this PR; keep it short and informative -->
<!-- If it is a bug fix, describe what the bug was and how you fixed it -->

We have changed the way our users should ask question, to be through our Slack channel. However, this is the last piece that is still pointing to the StackOverflow :)
