### PR TITLE
Robustify SUMO restart instance for RLlib at scale

### DIFF
--- a/flow/core/kernel/simulation/traci.py
+++ b/flow/core/kernel/simulation/traci.py
@@ -237,8 +237,7 @@ class TraCISimulation(KernelSimulation):
                 # Opening the I/O thread to SUMO
                 self.sumo_proc = subprocess.Popen(
                     sumo_call,
-                    stdout=subprocess.DEVNULL,
-                    preexec_fn=os.setsid
+                    stdout=subprocess.DEVNULL
                 )
 
                 # wait a small period of time for the subprocess to activate


### PR DESCRIPTION
<!--
Thank you for contributing to Flow! 

Please make sure you keep the title of your pull request short and informative,
and that you fill in the following template accurately (don't forget to remove
the fields that you do not use and the example texts!). You can also add relevant labels in the right
sidebar.

-->

## Pull request information

- **Status**: ready to merge
- **Kind of changes**: bugfix
- **Related PR or issue**: ? (optional)

## Description
Bugfix - When running FLOW-SUMO as a simulation engine within RLlib's training loop, after some substantial amount of steps are accumulated, Flow's Env.reset() will call restart_instance method. When this happens, the process will tend to get stuck and won't manage to restart SUMO successfully to keep training. It appears restarting SUMO process as a daemon when running as a Ray remote process is the root cause, and removing the *setsid* argument solves the problem.
